### PR TITLE
Function `removeLiquidityReturn` overflow protection

### DIFF
--- a/solidity/contracts/converter/types/liquidity-pool-v2/LiquidityPoolV2Converter.sol
+++ b/solidity/contracts/converter/types/liquidity-pool-v2/LiquidityPoolV2Converter.sol
@@ -585,7 +585,7 @@ contract LiquidityPoolV2Converter is LiquidityPoolConverter {
             uint256 x = stakedBalances[primaryReserveToken].mul(AMPLIFICATION_FACTOR);
             uint256 y = reserveAmplifiedBalance(primaryReserveToken);
             (uint256 min, uint256 max) = x < y ? (x, y) : (y, x);
-            return _amount.mul(stakedBalance.mul(min)).div(totalSupply.mul(max));
+            return _amount.mul(stakedBalance).div(totalSupply).mul(min).div(max);
         }
         return stakedBalance;
     }

--- a/solidity/python/Utilities/V2Flow/engine/__init__.py
+++ b/solidity/python/Utilities/V2Flow/engine/__init__.py
@@ -65,7 +65,7 @@ class Branch():
         self.reserveStaked = add(self.reserveStaked, reserveAmount)
     def remLiquidity(self, pool, user, amount, lo, hi):
         supplyAmount = amount if amount != 'all' else self.smartToken.balanceOf[user]
-        reserveAmount = ratio(supplyAmount, mul(self.reserveStaked, lo), mul(self.smartToken.totalSupply, hi))
+        reserveAmount = ratio(ratio(supplyAmount, self.reserveStaked, self.smartToken.totalSupply), lo, hi)
         self.smartToken.burn(user, supplyAmount)
         self.reserveToken.transfer(pool, user, reserveAmount)
         self.reserveStaked = sub(self.reserveStaked, reserveAmount)


### PR DESCRIPTION
During the calculation of the amount to return upon liquidity-removal, we apply an exit-fee depending on the ratio between the primary token's staked balance and actual balance.

This yields a multiplication of 3 potentially-large values, which can lead to an overflow.
In order to reduce the probability of that, we multiply the returned amount by the exit-fee after calculating that amount (instead of incorporating that fee into the computation of that amount).