### PR TITLE
Reentrancy guard optimization

### DIFF
--- a/solidity/contracts/utility/ReentrancyGuard.sol
+++ b/solidity/contracts/utility/ReentrancyGuard.sol
@@ -8,8 +8,11 @@ pragma solidity 0.6.12;
   * indirectly) from within itself.
 */
 contract ReentrancyGuard {
-    // 1 while protected code is being executed, 0 otherwise
-    uint256 private locked = 0;
+    uint256 private constant UNLOCKED = 1;
+    uint256 private constant LOCKED = 2;
+
+    // LOCKED while protected code is being executed, UNLOCKED otherwise
+    uint256 private state = UNLOCKED;
 
     /**
       * @dev ensures instantiation only by sub-contracts
@@ -19,13 +22,13 @@ contract ReentrancyGuard {
     // protects a function against reentrancy attacks
     modifier protected() {
         _protected();
-        locked = 1;
+        state = LOCKED;
         _;
-        locked = 0;
+        state = UNLOCKED;
     }
 
     // error message binary size optimization
     function _protected() internal view {
-        require(locked == 0, "ERR_REENTRANCY");
+        require(state == UNLOCKED, "ERR_REENTRANCY");
     }
 }

--- a/solidity/contracts/utility/ReentrancyGuard.sol
+++ b/solidity/contracts/utility/ReentrancyGuard.sol
@@ -8,8 +8,8 @@ pragma solidity 0.6.12;
   * indirectly) from within itself.
 */
 contract ReentrancyGuard {
-    // true while protected code is being executed, false otherwise
-    bool private locked = false;
+    // 1 while protected code is being executed, 0 otherwise
+    uint256 private locked = 0;
 
     /**
       * @dev ensures instantiation only by sub-contracts
@@ -19,13 +19,13 @@ contract ReentrancyGuard {
     // protects a function against reentrancy attacks
     modifier protected() {
         _protected();
-        locked = true;
+        locked = 1;
         _;
-        locked = false;
+        locked = 0;
     }
 
     // error message binary size optimization
     function _protected() internal view {
-        require(!locked, "ERR_REENTRANCY");
+        require(locked == 0, "ERR_REENTRANCY");
     }
 }


### PR DESCRIPTION
Change the type of a storage variable from `bool` to `uint256`, in order to reduce gas-cost by ~1600 (2 storage-read operations).