### PR TITLE
Fix internal function `recentAverageRate`

### DIFF
--- a/solidity/contracts/converter/ConverterBase.sol
+++ b/solidity/contracts/converter/ConverterBase.sol
@@ -56,7 +56,7 @@ abstract contract ConverterBase is IConverter, TokenHandler, TokenHolder, Contra
     /**
       * @dev version number
     */
-    uint16 public constant version = 41;
+    uint16 public constant version = 42;
 
     IConverterAnchor public override anchor;            // converter anchor contract
     IWhitelist public override conversionWhitelist;     // whitelist contract with list of addresses that are allowed to use the converter

--- a/solidity/contracts/converter/types/liquidity-pool-v1/LiquidityPoolV1Converter.sol
+++ b/solidity/contracts/converter/types/liquidity-pool-v1/LiquidityPoolV1Converter.sol
@@ -242,6 +242,11 @@ contract LiquidityPoolV1Converter is LiquidityPoolConverter {
         // calculate the numerator and the denumerator of the new rate
         Fraction memory prevAverage = prevAverageRate;
 
+        // if the previous average rate was never calculated, the average rate is equal to the current rate
+        if (prevAverage.n == 0 && prevAverage.d == 0) {
+            return Fraction({ n: currentRateN, d: currentRateD });
+        }
+
         uint256 x = prevAverage.d.mul(currentRateN);
         uint256 y = prevAverage.n.mul(currentRateD);
 


### PR DESCRIPTION
If the previous average rate was never calculated, the average rate is equal to the current rate.
Note that after a pool is liquidated completely, the previous average rate may return to a 'never calculated' state, but there is no problem with that.