### PR TITLE
Code Cleanup

### DIFF
--- a/solidity/contracts/liquidity-protection/LiquidityProtection.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtection.sol
@@ -167,16 +167,16 @@ contract LiquidityProtection is TokenHandler, Utils, Owned, ReentrancyGuard, Tim
      *
      * @param _newOwner    the new owner of the store
      */
-    function transferStoreOwnership(address _newOwner) external {
-        transferOwnership(store, _newOwner);
+    function transferStoreOwnership(address _newOwner) external ownerOnly {
+        store.transferOwnership(_newOwner);
     }
 
     /**
      * @dev accepts the ownership of the store
      * can only be called by the contract owner
      */
-    function acceptStoreOwnership() external {
-        acceptOwnership(store);
+    function acceptStoreOwnership() external ownerOnly {
+        store.acceptOwnership();
     }
 
     /**
@@ -1191,25 +1191,6 @@ contract LiquidityProtection is TokenHandler, Utils, Owned, ReentrancyGuard, Tim
         }
 
         return 0;
-    }
-
-    /**
-     * @dev transfers the ownership of a contract
-     * can only be called by the contract owner
-     *
-     * @param _owned       the owned contract
-     * @param _newOwner    the new owner of the contract
-     */
-    function transferOwnership(IOwned _owned, address _newOwner) internal ownerOnly {
-        _owned.transferOwnership(_newOwner);
-    }
-
-    /**
-     * @dev accepts the ownership of a contract
-     * can only be called by the contract owner
-     */
-    function acceptOwnership(IOwned _owned) internal ownerOnly {
-        _owned.acceptOwnership();
     }
 
     /**


### PR DESCRIPTION
Remove a couple of `internal` functions that are used only once (put their code where each one of them is called from).

We previous used these functions in order to reduce code-size, when we had a few others of similar nature.

But now that this is no longer the case, we may as well remove the "extra text" (and in addition to that, the `onlyOwner` modifier being applied on internal functions is generally bad practice; it was done so in order to reduce the code-size, but it is no longer useful for this purpose at this point).