### PR TITLE
Patch OZ Test Environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
         "npm": "^3.0.0"
     },
     "scripts": {
-        "install": "node scripts/fix-modules.js",
+        "postinstall": "node scripts/fix-modules.js",
         "build": "truffle compile",
         "test": "npm run build && npm run qtest",
         "qtest": "mocha",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
         "npm": "^3.0.0"
     },
     "scripts": {
+        "install": "node scripts/fix-modules.js",
         "build": "truffle compile",
         "test": "npm run build && npm run qtest",
         "qtest": "mocha",

--- a/scripts/fix-modules.js
+++ b/scripts/fix-modules.js
@@ -1,18 +1,18 @@
-const fs = require("fs");
+const fs = require('fs');
 
 function fix(fileName, tokens) {
-    console.log("Fixing " + fileName);
+    console.log('Fixing ' + fileName);
     try {
-        let data = fs.readFileSync(fileName, {encoding: "utf8"});
+        let data = fs.readFileSync(fileName, {encoding: 'utf8'});
         for (const token of tokens)
             data = data.split(token.prev).join(token.next);
-        fs.writeFileSync(fileName, data, {encoding: "utf8"});
+        fs.writeFileSync(fileName, data, {encoding: 'utf8'});
     }
     catch (error) {
         console.log(error.message);
     }
 }
 
-fix("./node_modules/@openzeppelin/test-environment/node_modules/ganache-core/node_modules/deferred-leveldown/deferred-leveldown.js",
-    [{prev: "function DeferredLevelDOWN (db) {", next: "function DeferredLevelDOWN(db) {db.db = require('memdown')();"}]
+fix('./node_modules/@openzeppelin/test-environment/node_modules/ganache-core/node_modules/deferred-leveldown/deferred-leveldown.js',
+    [{prev: 'function DeferredLevelDOWN (db) {', next: 'function DeferredLevelDOWN(db) {db.db = require(\'memdown\')();'}]
 );

--- a/scripts/fix-modules.js
+++ b/scripts/fix-modules.js
@@ -1,0 +1,18 @@
+const fs = require("fs");
+
+function fix(fileName, tokens) {
+    console.log("Fixing " + fileName);
+    try {
+        let data = fs.readFileSync(fileName, {encoding: "utf8"});
+        for (const token of tokens)
+            data = data.split(token.prev).join(token.next);
+        fs.writeFileSync(fileName, data, {encoding: "utf8"});
+    }
+    catch (error) {
+        console.log(error.message);
+    }
+}
+
+fix("./node_modules/@openzeppelin/test-environment/node_modules/ganache-core/node_modules/deferred-leveldown/deferred-leveldown.js",
+    [{prev: "function DeferredLevelDOWN (db) {", next: "function DeferredLevelDOWN(db) {db.db = require('memdown')();"}]
+);

--- a/scripts/fix-modules.js
+++ b/scripts/fix-modules.js
@@ -3,16 +3,22 @@ const fs = require('fs');
 function fix(fileName, tokens) {
     console.log('Fixing ' + fileName);
     try {
-        let data = fs.readFileSync(fileName, {encoding: 'utf8'});
-        for (const token of tokens)
+        let data = fs.readFileSync(fileName, { encoding: 'utf8' });
+        for (const token of tokens) {
             data = data.split(token.prev).join(token.next);
-        fs.writeFileSync(fileName, data, {encoding: 'utf8'});
-    }
-    catch (error) {
+        }
+        fs.writeFileSync(fileName, data, { encoding: 'utf8' });
+    } catch (error) {
         console.log(error.message);
     }
 }
 
-fix('./node_modules/@openzeppelin/test-environment/node_modules/ganache-core/node_modules/deferred-leveldown/deferred-leveldown.js',
-    [{prev: 'function DeferredLevelDOWN (db) {', next: 'function DeferredLevelDOWN(db) {db.db = require(\'memdown\')();'}]
+fix(
+    './node_modules/@openzeppelin/test-environment/node_modules/ganache-core/node_modules/deferred-leveldown/deferred-leveldown.js',
+    [
+        {
+            prev: 'function DeferredLevelDOWN (db) {',
+            next: "function DeferredLevelDOWN(db) {db.db = require('memdown')();"
+        }
+    ]
 );


### PR DESCRIPTION
OZ test environment currently does not support configuring ganache to avoid disk I/O, which significantly increases test execution time.

This commit adds a "hot-fix" of OZ source code (editing of an internal source file at the end of `npm install`), which forces the above configuration.

It is of course not guaranteed to be backward-compatible and work correctly on the next version of the OZ Test Environment, but hopefully it will remain so (backward-compatible) until they fix this issue (i.e., before they change the file being patched here).

We may require that NodeJS will be configured with `--max-old-space-size=4096` when `npm run qtest` is executed (i.e., we may need to update the corresponding entry in our `package.json`).