### PR TITLE
LP contracts Cleanup

### DIFF
--- a/solidity/contracts/liquidity-protection/LiquidityProtection.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtection.sol
@@ -210,32 +210,6 @@ contract LiquidityProtection is ILiquidityProtection, TokenHandler, Utils, Owned
     }
 
     /**
-     * @dev migrates all funds from the store to the wallet
-     * @dev migrates system balances from the store to the system-store
-     * @dev migrates minted amounts from the settings to the system-store
-     */
-    function migrateData() external {
-        // save local copies of storage variables
-        address storeAddress = address(store);
-        address walletAddress = address(wallet);
-        IERC20Token networkTokenLocal = networkToken;
-
-        address[] memory poolWhitelist = settings.poolWhitelist();
-        for (uint256 i = 0; i < poolWhitelist.length; i++) {
-            IERC20Token poolToken = IERC20Token(poolWhitelist[i]);
-            store.withdrawTokens(poolToken, walletAddress, poolToken.balanceOf(storeAddress));
-            uint256 systemBalance = store.systemBalance(poolToken);
-            systemStore.incSystemBalance(poolToken, systemBalance);
-            store.decSystemBalance(poolToken, systemBalance);
-            uint256 networkTokensMinted = settings.networkTokensMinted(IConverterAnchor(address(poolToken)));
-            systemStore.incNetworkTokensMinted(IConverterAnchor(address(poolToken)), networkTokensMinted);
-            settings.decNetworkTokensMinted(IConverterAnchor(address(poolToken)), networkTokensMinted);
-        }
-
-        store.withdrawTokens(networkTokenLocal, walletAddress, networkTokenLocal.balanceOf(storeAddress));
-    }
-
-    /**
      * @dev sets the events subscriber
      */
     function setEventsSubscriber(ILiquidityProtectionEventsSubscriber _eventsSubscriber)

--- a/solidity/contracts/liquidity-protection/LiquidityProtectionSettings.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtectionSettings.sol
@@ -22,9 +22,6 @@ contract LiquidityProtectionSettings is ILiquidityProtectionSettings, AccessCont
     // the owner role is used to update the settings
     bytes32 public constant ROLE_OWNER = keccak256("ROLE_OWNER");
 
-    // the minted tokens admin role is used to update the amount of minted tokens per pool
-    bytes32 public constant ROLE_MINTED_TOKENS_ADMIN = keccak256("ROLE_MINTED_TOKENS_ADMIN");
-
     uint32 private constant PPM_RESOLUTION = 1000000;
 
     IERC20Token public immutable networkToken;
@@ -36,7 +33,6 @@ contract LiquidityProtectionSettings is ILiquidityProtectionSettings, AccessCont
     uint256 public override minNetworkTokenLiquidityForMinting = 1000e18;
     uint256 public override defaultNetworkTokenMintingLimit = 20000e18;
     mapping(IConverterAnchor => uint256) public override networkTokenMintingLimits;
-    mapping(IConverterAnchor => uint256) public override networkTokensMinted;
 
     // number of seconds until any protection is in effect
     uint256 public override minProtectionDelay = 30 days;
@@ -85,15 +81,6 @@ contract LiquidityProtectionSettings is ILiquidityProtectionSettings, AccessCont
      * @param _newLimit     new limit
      */
     event NetworkTokenMintingLimitUpdated(IConverterAnchor indexed _poolAnchor, uint256 _prevLimit, uint256 _newLimit);
-
-    /**
-     * @dev triggered when the amount of network tokens minted into a specific pool is updated
-     *
-     * @param _poolAnchor  pool anchor
-     * @param _prevAmount  previous amount
-     * @param _newAmount   new amount
-     */
-    event NetworkTokensMintedUpdated(IConverterAnchor indexed _poolAnchor, uint256 _prevAmount, uint256 _newAmount);
 
     /**
      * @dev triggered when the protection delays are updated
@@ -148,7 +135,6 @@ contract LiquidityProtectionSettings is ILiquidityProtectionSettings, AccessCont
     {
         // set up administrative roles.
         _setRoleAdmin(ROLE_OWNER, ROLE_OWNER);
-        _setRoleAdmin(ROLE_MINTED_TOKENS_ADMIN, ROLE_OWNER);
 
         // allow the deployer to initially govern the contract.
         _setupRole(ROLE_OWNER, msg.sender);
@@ -164,16 +150,6 @@ contract LiquidityProtectionSettings is ILiquidityProtectionSettings, AccessCont
     // error message binary size optimization
     function _onlyOwner() internal view {
         require(hasRole(ROLE_OWNER, msg.sender), "ERR_ACCESS_DENIED");
-    }
-
-    modifier onlyMintedTokensAdmin() {
-        _onlyMintedTokensAdmin();
-        _;
-    }
-
-    // error message binary size optimization
-    function _onlyMintedTokensAdmin() internal view {
-        require(hasRole(ROLE_MINTED_TOKENS_ADMIN, msg.sender), "ERR_ACCESS_DENIED");
     }
 
     // ensures that the portion is valid
@@ -286,52 +262,6 @@ contract LiquidityProtectionSettings is ILiquidityProtectionSettings, AccessCont
         emit NetworkTokenMintingLimitUpdated(_poolAnchor, networkTokenMintingLimits[_poolAnchor], _limit);
 
         networkTokenMintingLimits[_poolAnchor] = _limit;
-    }
-
-    /**
-     * @dev increases the amount of network tokens minted into a specific pool
-     * can only be called by the minted tokens admin
-     *
-     * @param _poolAnchor   pool anchor
-     * @param _amount       amount to increase the minted tokens by
-     */
-    function incNetworkTokensMinted(IConverterAnchor _poolAnchor, uint256 _amount)
-        external
-        override
-        onlyMintedTokensAdmin
-        validAddress(address(_poolAnchor))
-    {
-        uint256 prevAmount = networkTokensMinted[_poolAnchor];
-        uint256 newAmount = prevAmount.add(_amount);
-        networkTokensMinted[_poolAnchor] = newAmount;
-
-        emit NetworkTokensMintedUpdated(_poolAnchor, prevAmount, newAmount);
-    }
-
-    /**
-     * @dev decreases the amount of network tokens minted into a specific pool
-     * can only be called by the minted tokens admin
-     *
-     * @param _poolAnchor   pool anchor
-     * @param _amount       amount to decrease the minted tokens by
-     */
-    function decNetworkTokensMinted(IConverterAnchor _poolAnchor, uint256 _amount)
-        external
-        override
-        onlyMintedTokensAdmin
-        validAddress(address(_poolAnchor))
-    {
-        uint256 prevAmount = networkTokensMinted[_poolAnchor];
-
-        // allow the amount to reset to 0 if the provided amount is higher than the previous amount
-        uint256 newAmount = 0;
-        if (_amount < prevAmount) {
-            newAmount = prevAmount.sub(_amount);
-        }
-
-        networkTokensMinted[_poolAnchor] = newAmount;
-
-        emit NetworkTokensMintedUpdated(_poolAnchor, prevAmount, newAmount);
     }
 
     /**

--- a/solidity/contracts/liquidity-protection/interfaces/ILiquidityProtectionSettings.sol
+++ b/solidity/contracts/liquidity-protection/interfaces/ILiquidityProtectionSettings.sol
@@ -23,12 +23,6 @@ interface ILiquidityProtectionSettings {
 
     function networkTokenMintingLimits(IConverterAnchor _poolAnchor) external view returns (uint256);
 
-    function networkTokensMinted(IConverterAnchor _poolAnchor) external view returns (uint256);
-
-    function incNetworkTokensMinted(IConverterAnchor _poolAnchor, uint256 _amount) external;
-
-    function decNetworkTokensMinted(IConverterAnchor _poolAnchor, uint256 _amount) external;
-
     function minProtectionDelay() external view returns (uint256);
 
     function maxProtectionDelay() external view returns (uint256);

--- a/solidity/test/LiquidityProtectionAverageRate.js
+++ b/solidity/test/LiquidityProtectionAverageRate.js
@@ -4,7 +4,7 @@ const { expect } = require('../../chai-local');
 const { registry, roles } = require('./helpers/Constants');
 const Decimal = require('decimal.js');
 
-const { ROLE_OWNER, ROLE_MINTED_TOKENS_ADMIN, ROLE_GOVERNOR, ROLE_MINTER } = roles;
+const { ROLE_OWNER, ROLE_GOVERNOR, ROLE_MINTER } = roles;
 
 const ContractRegistry = contract.fromArtifact('ContractRegistry');
 const BancorFormula = contract.fromArtifact('BancorFormula');
@@ -107,7 +107,6 @@ describe('LiquidityProtectionAverageRate', () => {
                 ]);
 
                 await liquidityProtectionSettings.grantRole(ROLE_OWNER, liquidityProtection.address, { from: owner });
-                await liquidityProtectionSettings.grantRole(ROLE_MINTED_TOKENS_ADMIN, owner, { from: owner });
                 await liquidityProtectionStats.grantRole(ROLE_OWNER, liquidityProtection.address, { from: owner });
                 await liquidityProtectionSystemStore.grantRole(ROLE_OWNER, liquidityProtection.address, {
                     from: owner

--- a/solidity/test/LiquidityProtectionEdgeCases.js
+++ b/solidity/test/LiquidityProtectionEdgeCases.js
@@ -5,7 +5,7 @@ const { registry, roles } = require('./helpers/Constants');
 const Decimal = require('decimal.js');
 
 const { ZERO_ADDRESS, MAX_UINT256 } = constants;
-const { ROLE_OWNER, ROLE_MINTED_TOKENS_ADMIN, ROLE_GOVERNOR, ROLE_MINTER } = roles;
+const { ROLE_OWNER, ROLE_GOVERNOR, ROLE_MINTER } = roles;
 
 const ContractRegistry = contract.fromArtifact('ContractRegistry');
 const BancorFormula = contract.fromArtifact('BancorFormula');
@@ -213,9 +213,6 @@ describe('LiquidityProtectionEdgeCases', () => {
                     checkpointStore.address
                 ]);
 
-                await liquidityProtectionSettings.grantRole(ROLE_MINTED_TOKENS_ADMIN, liquidityProtection.address, {
-                    from: owner
-                });
                 await liquidityProtectionStats.grantRole(ROLE_OWNER, liquidityProtection.address, { from: owner });
                 await liquidityProtectionSystemStore.grantRole(ROLE_OWNER, liquidityProtection.address, {
                     from: owner

--- a/solidity/test/helpers/Constants.js
+++ b/solidity/test/helpers/Constants.js
@@ -19,7 +19,6 @@ module.exports = {
         ROLE_OWNER: web3.utils.keccak256('ROLE_OWNER'),
         ROLE_GOVERNOR: web3.utils.keccak256('ROLE_GOVERNOR'),
         ROLE_MINTER: web3.utils.keccak256('ROLE_MINTER'),
-        ROLE_MINTED_TOKENS_ADMIN: web3.utils.keccak256('ROLE_MINTED_TOKENS_ADMIN'),
         ROLE_SEEDER: web3.utils.keccak256('ROLE_SEEDER')
     },
 

--- a/solidity/utils/test_deployment.js
+++ b/solidity/utils/test_deployment.js
@@ -13,7 +13,6 @@ const MIN_GAS_LIMIT = 100000;
 const ROLE_OWNER = Web3.utils.keccak256('ROLE_OWNER');
 const ROLE_GOVERNOR = Web3.utils.keccak256('ROLE_GOVERNOR');
 const ROLE_MINTER = Web3.utils.keccak256('ROLE_MINTER');
-const ROLE_MINTED_TOKENS_ADMIN = Web3.utils.keccak256('ROLE_MINTED_TOKENS_ADMIN');
 
 const getConfig = () => {
     return JSON.parse(fs.readFileSync(CFG_FILE_NAME, { encoding: 'utf8' }));
@@ -390,9 +389,6 @@ const run = async () => {
     await execute(bntTokenGovernance.methods.grantRole(ROLE_MINTER, liquidityProtection._address));
     await execute(vbntTokenGovernance.methods.grantRole(ROLE_MINTER, liquidityProtection._address));
 
-    await execute(
-        liquidityProtectionSettings.methods.grantRole(ROLE_MINTED_TOKENS_ADMIN, liquidityProtection._address)
-    );
     await execute(liquidityProtectionStats.methods.grantRole(ROLE_OWNER, liquidityProtection._address));
     await execute(liquidityProtectionSystemStore.methods.grantRole(ROLE_OWNER, liquidityProtection._address));
 


### PR DESCRIPTION
1. Remove the 'MintedNetworkToken' functionality from `LiquidityProtectionSettings`.
2. Remove the 'migrateData' function from `LiquidityProtection`.
