### PR TITLE
Fix call to function `addLiquidity` in contract `StandardPoolConverter`

### DIFF
--- a/solidity/utils/test_deployment.js
+++ b/solidity/utils/test_deployment.js
@@ -315,7 +315,7 @@ const run = async () => {
 
             const deployedConverterType = {1: 'LiquidityPoolV1Converter', 3: 'StandardPoolConverter'}[type];
             const deployedConverter = deployed(web3, deployedConverterType, converterBase._address);
-            await execute(deployedConverter.methods.addLiquidity(tokens, amounts, 1), value);
+            await execute(deployedConverter.methods['addLiquidity(address[],uint256[],uint256)'](tokens, amounts, 1), value);
         }
 
         reserves[converter.symbol] = {


### PR DESCRIPTION
Since we have 2 overloaded versions of function `addLiquidity` in contract `StandardPoolConverter`, call the desired one explicitly.