### PR TITLE
Remove/consolidate `notThis` modifiers

### DIFF
--- a/solidity/contracts/bancorx/BancorX.sol
+++ b/solidity/contracts/bancorx/BancorX.sol
@@ -142,8 +142,7 @@ contract BancorX is IBancorX, TokenHolder, ContractRegistryClient {
         greaterThanZero(_minLimit)
         greaterThanZero(_limitIncPerBlock)
         greaterThanZero(_minRequiredReports)
-        validAddress(address(_token))
-        notThis(address(_token))
+        validExternalAddress(address(_token))
     {
         // validate input
         require(_minLimit <= _maxLockLimit && _minLimit <= _maxReleaseLimit, "ERR_INVALID_MIN_LIMIT");

--- a/solidity/contracts/converter/ConverterBase.sol
+++ b/solidity/contracts/converter/ConverterBase.sol
@@ -183,7 +183,7 @@ abstract contract ConverterBase is ConverterVersion, IConverter, TokenHolder, Co
      *
      * @param _whitelist    address of a whitelist contract
      */
-    function setConversionWhitelist(IWhitelist _whitelist) public ownerOnly notThis(address(_whitelist)) {
+    function setConversionWhitelist(IWhitelist _whitelist) public ownerOnly {
         conversionWhitelist = _whitelist;
     }
 
@@ -300,8 +300,7 @@ abstract contract ConverterBase is ConverterVersion, IConverter, TokenHolder, Co
         override
         ownerOnly
         inactive
-        validAddress(address(_token))
-        notThis(address(_token))
+        validExternalAddress(address(_token))
         validReserveWeight(_weight)
     {
         // validate input

--- a/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
+++ b/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
@@ -325,8 +325,7 @@ contract StandardPoolConverter is
         override
         ownerOnly
         inactive
-        validAddress(address(_token))
-        notThis(address(_token))
+        validExternalAddress(address(_token))
         validReserveWeight(_weight)
     {
         // validate input

--- a/solidity/contracts/liquidity-protection/LiquidityProtectionSettings.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtectionSettings.sol
@@ -152,8 +152,7 @@ contract LiquidityProtectionSettings is ILiquidityProtectionSettings, AccessCont
     constructor(IERC20 token, IContractRegistry registry)
         public
         ContractRegistryClient(registry)
-        validAddress(address(token))
-        notThis(address(token))
+        validExternalAddress(address(token))
     {
         // set up administrative roles.
         _setRoleAdmin(ROLE_OWNER, ROLE_OWNER);
@@ -289,12 +288,7 @@ contract LiquidityProtectionSettings is ILiquidityProtectionSettings, AccessCont
      *
      * @param poolAnchor    pool anchor
      */
-    function addPoolToWhitelist(IConverterAnchor poolAnchor)
-        external
-        onlyOwner
-        validAddress(address(poolAnchor))
-        notThis(address(poolAnchor))
-    {
+    function addPoolToWhitelist(IConverterAnchor poolAnchor) external onlyOwner validAddress(address(poolAnchor)) {
         require(_poolWhitelist.add(address(poolAnchor)), "ERR_POOL_ALREADY_WHITELISTED");
 
         emit PoolWhitelistUpdated(poolAnchor, true);
@@ -306,12 +300,7 @@ contract LiquidityProtectionSettings is ILiquidityProtectionSettings, AccessCont
      *
      * @param poolAnchor    pool anchor
      */
-    function removePoolFromWhitelist(IConverterAnchor poolAnchor)
-        external
-        onlyOwner
-        validAddress(address(poolAnchor))
-        notThis(address(poolAnchor))
-    {
+    function removePoolFromWhitelist(IConverterAnchor poolAnchor) external onlyOwner {
         require(_poolWhitelist.remove(address(poolAnchor)), "ERR_POOL_NOT_WHITELISTED");
 
         emit PoolWhitelistUpdated(poolAnchor, false);
@@ -350,8 +339,7 @@ contract LiquidityProtectionSettings is ILiquidityProtectionSettings, AccessCont
     function addSubscriber(ILiquidityProtectionEventsSubscriber subscriber)
         external
         onlyOwner
-        validAddress(address(subscriber))
-        notThis(address(subscriber))
+        validExternalAddress(address(subscriber))
     {
         require(_subscribers.add(address(subscriber)), "ERR_SUBSCRIBER_ALREADY_SET");
 
@@ -364,12 +352,7 @@ contract LiquidityProtectionSettings is ILiquidityProtectionSettings, AccessCont
      *
      * @param subscriber    subscriber address
      */
-    function removeSubscriber(ILiquidityProtectionEventsSubscriber subscriber)
-        external
-        onlyOwner
-        validAddress(address(subscriber))
-        notThis(address(subscriber))
-    {
+    function removeSubscriber(ILiquidityProtectionEventsSubscriber subscriber) external onlyOwner {
         require(_subscribers.remove(address(subscriber)), "ERR_INVALID_SUBSCRIBER");
 
         emit SubscriberUpdated(subscriber, false);

--- a/solidity/contracts/liquidity-protection/LiquidityProtectionSettings.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtectionSettings.sol
@@ -275,7 +275,11 @@ contract LiquidityProtectionSettings is ILiquidityProtectionSettings, AccessCont
      *
      * @param poolAnchor    pool anchor
      */
-    function addPoolToWhitelist(IConverterAnchor poolAnchor) external onlyOwner validAddress(address(poolAnchor)) {
+    function addPoolToWhitelist(IConverterAnchor poolAnchor)
+        external
+        onlyOwner
+        validExternalAddress(address(poolAnchor))
+    {
         require(_poolWhitelist.add(address(poolAnchor)), "ERR_POOL_ALREADY_WHITELISTED");
 
         emit PoolWhitelistUpdated(poolAnchor, true);

--- a/solidity/contracts/liquidity-protection/LiquidityProtectionStore.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtectionStore.sol
@@ -138,7 +138,7 @@ contract LiquidityProtectionStore is ILiquidityProtectionStore, Owned, Utils {
         IERC20 _token,
         address _to,
         uint256 _amount
-    ) external override ownerOnly validAddress(_to) notThis(_to) {
+    ) external override ownerOnly validExternalAddress(_to) {
         _token.safeTransfer(_to, _amount);
     }
 
@@ -440,8 +440,7 @@ contract LiquidityProtectionStore is ILiquidityProtectionStore, Owned, Utils {
         external
         override
         ownerOnly
-        validAddress(_provider)
-        notThis(_provider)
+        validExternalAddress(_provider)
         greaterThanZero(_amount)
         greaterThanZero(_expirationTime)
         returns (uint256)

--- a/solidity/contracts/token/DSToken.sol
+++ b/solidity/contracts/token/DSToken.sol
@@ -57,7 +57,7 @@ contract DSToken is IDSToken, ERC20, Owned, Utils {
      * @param _to      account to receive the new amount
      * @param _amount  amount to increase the supply by
      */
-    function issue(address _to, uint256 _amount) public override ownerOnly validAddress(_to) notThis(_to) {
+    function issue(address _to, uint256 _amount) public override ownerOnly validExternalAddress(_to) {
         _mint(_to, _amount);
 
         emit Issuance(_amount);

--- a/solidity/contracts/utility/TokenHolder.sol
+++ b/solidity/contracts/utility/TokenHolder.sol
@@ -34,7 +34,7 @@ contract TokenHolder is ITokenHolder, Owned, Utils {
         IERC20 _token,
         address _to,
         uint256 _amount
-    ) public virtual override ownerOnly validAddress(address(_token)) validAddress(_to) notThis(_to) {
+    ) public virtual override ownerOnly validAddress(address(_token)) validAddress(_to) {
         _token.safeTransfer(_to, _amount);
     }
 }

--- a/solidity/contracts/utility/Utils.sol
+++ b/solidity/contracts/utility/Utils.sol
@@ -27,17 +27,6 @@ contract Utils {
         require(_address != address(0), "ERR_INVALID_ADDRESS");
     }
 
-    // verifies that the address is different than this contract address
-    modifier notThis(address _address) {
-        _notThis(_address);
-        _;
-    }
-
-    // error message binary size optimization
-    function _notThis(address _address) internal view {
-        require(_address != address(this), "ERR_ADDRESS_IS_SELF");
-    }
-
     // validates an external address - currently only checks that it isn't null or this
     modifier validExternalAddress(address _address) {
         _validExternalAddress(_address);

--- a/solidity/test/Converter.js
+++ b/solidity/test/Converter.js
@@ -285,12 +285,6 @@ describe('Converter', () => {
 
                         expect(whitelist).to.eql(ZERO_ADDRESS);
                     });
-
-                    it('should revert when the owner attempts update the conversion whitelist contract address with the converter address', async () => {
-                        const converter = await initConverter(type, false, isETHReserve);
-
-                        await expectRevert(converter.setConversionWhitelist(converter.address), 'ERR_ADDRESS_IS_SELF');
-                    });
                 }
 
                 it('verifies the owner can update the fee', async () => {
@@ -361,7 +355,7 @@ describe('Converter', () => {
 
                         await expectRevert(
                             converter.addReserve(ZERO_ADDRESS, WEIGHT_10_PERCENT),
-                            'ERR_INVALID_ADDRESS'
+                            'ERR_INVALID_EXTERNAL_ADDRESS.'
                         );
                     });
 
@@ -392,16 +386,6 @@ describe('Converter', () => {
                         await expectRevert(
                             converter.addReserve(anchorAddress, WEIGHT_10_PERCENT),
                             'ERR_INVALID_RESERVE'
-                        );
-                    });
-
-                    it('should revert when attempting to add the converter as a reserve', async () => {
-                        await createAnchor();
-                        const converter = await createConverter(type, anchorAddress);
-
-                        await expectRevert(
-                            converter.addReserve(converter.address, WEIGHT_10_PERCENT),
-                            'ERR_ADDRESS_IS_SELF'
                         );
                     });
 

--- a/solidity/test/DSToken.js
+++ b/solidity/test/DSToken.js
@@ -46,11 +46,11 @@ describe('DSToken', () => {
     });
 
     it('should revert when the owner attempts to issue tokens to an invalid address', async () => {
-        await expectRevert(token.issue(ZERO_ADDRESS, new BN(1)), 'ERR_INVALID_ADDRESS');
+        await expectRevert(token.issue(ZERO_ADDRESS, new BN(1)), 'ERR_INVALID_EXTERNAL_ADDRESS');
     });
 
     it('should revert when the owner attempts to issue tokens to the token address', async () => {
-        await expectRevert(token.issue(token.address, new BN(1)), 'ERR_ADDRESS_IS_SELF');
+        await expectRevert(token.issue(token.address, new BN(1)), 'ERR_INVALID_EXTERNAL_ADDRESS');
     });
 
     it('should revert when a non owner attempts to issue tokens', async () => {

--- a/solidity/test/LiquidityProtectionSettings.js
+++ b/solidity/test/LiquidityProtectionSettings.js
@@ -1,7 +1,9 @@
 const { accounts, defaultSender, contract } = require('@openzeppelin/test-environment');
-const { expectRevert, expectEvent, BN } = require('@openzeppelin/test-helpers');
+const { expectRevert, expectEvent, BN, constants } = require('@openzeppelin/test-helpers');
 const { expect } = require('../../chai-local');
 const { NATIVE_TOKEN_ADDRESS, registry, roles } = require('./helpers/Constants');
+
+const { ZERO_ADDRESS } = constants;
 
 const { ROLE_OWNER } = roles;
 
@@ -112,6 +114,14 @@ describe('LiquidityProtectionSettings', () => {
                 settings.removePoolFromWhitelist(poolToken.address, { from: owner }),
                 'ERR_POOL_NOT_WHITELISTED'
             );
+        });
+
+        it('should revert when an owner attempts to whitelist a zero address pool', async () => {
+            await expectRevert(settings.addPoolToWhitelist(ZERO_ADDRESS), 'ERR_INVALID_EXTERNAL_ADDRESS');
+        });
+
+        it('should revert when an owner attempts to whitelist the settings contract itself', async () => {
+            await expectRevert(settings.addPoolToWhitelist(settings.address), 'ERR_INVALID_EXTERNAL_ADDRESS');
         });
 
         it('should succeed when an owner attempts to add a whitelisted pool', async () => {

--- a/solidity/test/TokenHolder.js
+++ b/solidity/test/TokenHolder.js
@@ -44,10 +44,6 @@ describe('TokenHolder', () => {
         await expectRevert(holder.withdrawTokens(erc20Token.address, ZERO_ADDRESS, new BN(1)), 'ERR_INVALID_ADDRESS');
     });
 
-    it('should revert when attempting to withdraw tokens to the holder address', async () => {
-        await expectRevert(holder.withdrawTokens(erc20Token.address, holder.address, new BN(1)), 'ERR_ADDRESS_IS_SELF');
-    });
-
     it('should revert when attempting to withdraw an amount greater than the holder balance', async () => {
         const balance = await erc20Token.balanceOf.call(holder.address);
 


### PR DESCRIPTION
In this PR, I have consolidated `validAddress` and `notThis` into the existing `validExternalAddress` modifiers. 

Please note, that in some of the cases I've removed `notThis` and kept only `validAddess` (e.g., when the wrong address can be changed back, when removing a previously verified address, etc.)