### PR TITLE
Common utility function `networkWalletAndFees`

### DIFF
--- a/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
+++ b/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
@@ -1215,11 +1215,11 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
      * @return the average number of decimal digits in the given list of positive integers
      */
     function geometricMean(uint256[2] memory list) private pure returns (uint256) {
-        uint256[] memory dynamicArr = new uint256[](2);
+        uint256[] memory tempList = new uint256[](2);
         for (uint256 i = 0; i < 2; i++) {
-            dynamicArr[i] = list[i];
+            tempList[i] = list[i];
         }
-        return MathEx.geometricMean(dynamicArr);
+        return MathEx.geometricMean(tempList);
     }
 
     function crossReserveTargetAmount(

--- a/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
+++ b/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
@@ -1328,14 +1328,14 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
         uint256 prevPoint = floorSqrt(_reserveBalancesProduct);
         uint256 currPoint = floorSqrt(reserveBalance0 * reserveBalance1);
 
-        if (currPoint > prevPoint) {
-            (address networkFeeWallet, uint32 networkFee) = INetworkSettings(addressOf(NETWORK_SETTINGS)).networkFeeParams();
-            uint256 n = (currPoint - prevPoint) * networkFee;
-            uint256 d = (currPoint * (PPM_RESOLUTION - networkFee)).add(prevPoint * networkFee * 2);
-            return (networkFeeWallet, reserveBalance0.mul(n).div(d), reserveBalance1.mul(n).div(d));
+        if (prevPoint >= currPoint) {
+            return (address(0), 0, 0);
         }
 
-        return (address(0), 0, 0);
+        (address networkFeeWallet, uint32 networkFee) = INetworkSettings(addressOf(NETWORK_SETTINGS)).networkFeeParams();
+        uint256 n = (currPoint - prevPoint) * networkFee;
+        uint256 d = (currPoint * (PPM_RESOLUTION - networkFee)).add(prevPoint * networkFee * 2);
+        return (networkFeeWallet, reserveBalance0.mul(n).div(d), reserveBalance1.mul(n).div(d));
     }
 
     /**

--- a/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
+++ b/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
@@ -1216,9 +1216,8 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
      */
     function geometricMean(uint256[2] memory list) private pure returns (uint256) {
         uint256[] memory tempList = new uint256[](2);
-        for (uint256 i = 0; i < 2; i++) {
-            tempList[i] = list[i];
-        }
+        tempList[0] = list[0];
+        tempList[1] = list[1];
         return MathEx.geometricMean(tempList);
     }
 

--- a/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
+++ b/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
@@ -1201,6 +1201,32 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
         return _averageRateInfo & MAX_UINT112;
     }
 
+    /**
+     * @dev returns the largest integer smaller than or equal to the square root of a given value
+     *
+     * @param _num the given value
+     *
+     * @return the largest integer smaller than or equal to the square root of the given value
+     */
+    function floorSqrt(uint256 x) private pure returns (uint256) {
+        return x > 0 ? MathEx.floorSqrt(x) : 0;
+    }
+
+    /**
+     * @dev returns the average number of decimal digits in a given list of positive integers
+     *
+     * @param _values  list of positive integers
+     *
+     * @return the average number of decimal digits in the given list of positive integers
+     */
+    function geometricMean(uint256[2] memory _reserveAmounts) private pure returns (uint256) {
+        uint256[] memory reserveAmounts = new uint256[](2);
+        for (uint256 i = 0; i < 2; i++) {
+            reserveAmounts[i] = _reserveAmounts[i];
+        }
+        return MathEx.geometricMean(reserveAmounts);
+    }
+
     function crossReserveTargetAmount(
         uint256 _sourceReserveBalance,
         uint256 _targetReserveBalance,
@@ -1210,18 +1236,6 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
         require(_sourceReserveBalance > 0 && _targetReserveBalance > 0, "ERR_INVALID_RESERVE_BALANCE");
 
         return _targetReserveBalance.mul(_amount) / _sourceReserveBalance.add(_amount);
-    }
-
-    function geometricMean(uint256[2] memory _reserveAmounts) private pure returns (uint256) {
-        uint256[] memory reserveAmounts = new uint256[](2);
-        for (uint256 i = 0; i < 2; i++) {
-            reserveAmounts[i] = _reserveAmounts[i];
-        }
-        return MathEx.geometricMean(reserveAmounts);
-    }
-
-    function floorSqrt(uint256 x) private pure returns (uint256) {
-        return x > 0 ? MathEx.floorSqrt(x) : 0;
     }
 
     function crossReserveSourceAmount(

--- a/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
+++ b/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
@@ -808,17 +808,13 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
         (oldReserveBalances[0], oldReserveBalances[1]) = processNetworkFees(msg.value);
 
         uint256 amount;
-        uint256[2] memory reserveAmounts;
 
         // calculate the amount of pool tokens to mint for the caller
         // and the amount of reserve tokens to transfer from the caller
         if (totalSupply == 0) {
             amount = geometricMean(_reserveAmounts);
-            for (uint256 i = 0; i < 2; i++) {
-                reserveAmounts[i] = _reserveAmounts[i];
-            }
         } else {
-            (amount, reserveAmounts) = addLiquidityAmounts(
+            (amount, _reserveAmounts) = addLiquidityAmounts(
                 _reserveTokens,
                 _reserveAmounts,
                 oldReserveBalances,
@@ -829,9 +825,8 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
         uint256 newPoolTokenSupply = totalSupply.add(amount);
         for (uint256 i = 0; i < 2; i++) {
             IERC20 reserveToken = _reserveTokens[i];
-            uint256 reserveAmount = reserveAmounts[i];
+            uint256 reserveAmount = _reserveAmounts[i];
             require(reserveAmount > 0, "ERR_ZERO_TARGET_AMOUNT");
-            assert(reserveAmount <= _reserveAmounts[i]);
 
             // transfer each one of the reserve amounts from the user to the pool
             if (reserveToken != NATIVE_TOKEN_ADDRESS) {
@@ -1204,7 +1199,7 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
     /**
      * @dev returns the largest integer smaller than or equal to the square root of a given value
      *
-     * @param _num the given value
+     * @param x the given value
      *
      * @return the largest integer smaller than or equal to the square root of the given value
      */
@@ -1215,16 +1210,16 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
     /**
      * @dev returns the average number of decimal digits in a given list of positive integers
      *
-     * @param _values  list of positive integers
+     * @param list list of positive integers
      *
      * @return the average number of decimal digits in the given list of positive integers
      */
-    function geometricMean(uint256[2] memory _reserveAmounts) private pure returns (uint256) {
-        uint256[] memory reserveAmounts = new uint256[](2);
+    function geometricMean(uint256[2] memory list) private pure returns (uint256) {
+        uint256[] memory dynamicArr = new uint256[](2);
         for (uint256 i = 0; i < 2; i++) {
-            reserveAmounts[i] = _reserveAmounts[i];
+            dynamicArr[i] = list[i];
         }
-        return MathEx.geometricMean(reserveAmounts);
+        return MathEx.geometricMean(dynamicArr);
     }
 
     function crossReserveTargetAmount(


### PR DESCRIPTION
Following the removal of function `baseReserveBalance`, unify the common code in function `baseReserveBalances` and function `processNetworkFees` into a dedicated function.