### PR TITLE
Fix add liquidity return and improve sp converter

### DIFF
--- a/solidity/contracts/converter/types/fixed-rate-pool/FixedRatePoolConverter.sol
+++ b/solidity/contracts/converter/types/fixed-rate-pool/FixedRatePoolConverter.sol
@@ -147,8 +147,8 @@ contract FixedRatePoolConverter is StandardPoolConverter {
      * @return amount of reserve tokens to transfer from the caller
      */
     function addLiquidityAmounts(
-        IERC20[] memory _reserveTokens,
-        uint256[] memory _reserveAmounts,
+        IERC20[2] memory _reserveTokens,
+        uint256[2] memory _reserveAmounts,
         uint256[2] memory _reserveBalances,
         uint256 _totalSupply
     ) internal view override returns (uint256, uint256[2] memory) {
@@ -156,14 +156,7 @@ contract FixedRatePoolConverter is StandardPoolConverter {
         uint256 rateD = _rate[_reserveTokens[1]];
         uint256 n = _reserveAmounts[0].mul(rateN).add(_reserveAmounts[1]).mul(rateD);
         uint256 d = _reserveBalances[0].mul(rateN).add(_reserveBalances[1]).mul(rateD);
-        uint256 amount = _totalSupply.mul(n).div(d);
-
-        uint256[2] memory reserveAmounts;
-        for (uint256 i = 0; i < 2; i++) {
-            reserveAmounts[i] = _reserveAmounts[i];
-        }
-
-        return (amount, reserveAmounts);
+        return (_totalSupply.mul(n).div(d), _reserveAmounts);
     }
 
     /**
@@ -173,7 +166,7 @@ contract FixedRatePoolConverter is StandardPoolConverter {
      *
      * @return true if at least one of the reserve amounts is larger than zero; false otherwise
      */
-    function validReserveAmounts(uint256[] memory _reserveAmounts) internal pure override returns (bool) {
+    function validReserveAmounts(uint256[2] memory _reserveAmounts) internal pure override returns (bool) {
         return _reserveAmounts[0] > 0 || _reserveAmounts[1] > 0;
     }
 }

--- a/solidity/contracts/converter/types/liquidity-pool-v1/LiquidityPoolV1Converter.sol
+++ b/solidity/contracts/converter/types/liquidity-pool-v1/LiquidityPoolV1Converter.sol
@@ -419,40 +419,42 @@ contract LiquidityPoolV1Converter is LiquidityPoolConverter, Time {
 
         uint256 totalSupply = IDSToken(address(anchor)).totalSupply();
         IBancorFormula formula = IBancorFormula(addressOf(BANCOR_FORMULA));
-        uint256 amount =
-            formula.fundSupplyAmount(
-                totalSupply,
-                reserves[_reserveTokens[_reserveTokenIndex]].balance,
-                reserveRatio,
-                _reserveAmount
-            );
+        uint256 amount = formula.fundSupplyAmount(
+            totalSupply,
+            reserves[_reserveTokens[_reserveTokenIndex]].balance,
+            reserveRatio,
+            _reserveAmount
+        );
 
-        for (uint256 i = 0; i < reserveAmounts.length; i++)
+        for (uint256 i = 0; i < reserveAmounts.length; i++) {
             reserveAmounts[i] = formula.fundCost(
                 totalSupply,
                 reserves[_reserveTokens[i]].balance,
                 reserveRatio,
                 amount
             );
+        }
 
         return reserveAmounts;
     }
 
     /**
-     * @dev given the amount of one of the reserve tokens to add liquidity of,
-     * returns the amount of pool tokens entitled for it
+     * @dev returns the amount of pool tokens entitled for given amounts of reserve tokens
      * since an empty pool can be funded with any list of non-zero input amounts,
      * this function assumes that the pool is not empty (has already been funded)
      *
-     * @param _reserveToken    address of the reserve token
-     * @param _reserveAmount   amount of the reserve token
+     * @param _reserveTokens   address of each reserve token
+     * @param _reserveAmounts  amount of each reserve token
      *
-     * @return the amount of pool tokens entitled
+     * @return the amount of pool tokens entitled for the given amounts of reserve tokens
      */
-    function addLiquidityReturn(IERC20 _reserveToken, uint256 _reserveAmount) public view returns (uint256) {
+    function addLiquidityReturn(
+        IERC20[] memory _reserveTokens,
+        uint256[] memory _reserveAmounts
+    ) public view returns (uint256) {
         uint256 totalSupply = IDSToken(address(anchor)).totalSupply();
         IBancorFormula formula = IBancorFormula(addressOf(BANCOR_FORMULA));
-        return formula.fundSupplyAmount(totalSupply, reserves[_reserveToken].balance, reserveRatio, _reserveAmount);
+        return getMinShare(formula, totalSupply, _reserveTokens, _reserveAmounts);
     }
 
     /**

--- a/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
+++ b/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
@@ -282,10 +282,10 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
      * @return array of reserve tokens
      */
     function reserveTokens() public view returns (IERC20[] memory) {
-        IERC20[] memory tempReserveToken = new IERC20[](2);
-        tempReserveToken[0] = __reserveTokens[0];
-        tempReserveToken[1] = __reserveTokens[1];
-        return tempReserveToken;
+        IERC20[] memory tempReserveTokens = new IERC20[](2);
+        tempReserveTokens[0] = __reserveTokens[0];
+        tempReserveTokens[1] = __reserveTokens[1];
+        return tempReserveTokens;
     }
 
     /**

--- a/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
+++ b/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
@@ -347,13 +347,17 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
     }
 
     /**
-     * @dev returns the balances of both reserve tokens
+     * @dev returns the reserve balances of the given reserve tokens
      *
-     * @return the balances of both reserve tokens
+     * @param _reserveTokens reserve tokens
+     *
+     * @return reserve balances
      */
-    function reserveBalancesArray() internal view returns (uint256[2] memory) {
-        (uint256 reserveBalance1, uint256 reserveBalance2) = reserveBalances(1, 2);
-        return [reserveBalance1, reserveBalance2];
+    function baseReserveBalances(IERC20[2] memory _reserveTokens) internal view returns (uint256[2] memory) {
+        uint256 reserveId0 = __reserveIds[_reserveTokens[0]];
+        uint256 reserveId1 = __reserveIds[_reserveTokens[1]];
+        (uint256 reserveBalance0, uint256 reserveBalance1) = reserveBalances(reserveId0, reserveId1);
+        return [reserveBalance0, reserveBalance1];
     }
 
     /**
@@ -851,6 +855,37 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
     }
 
     /**
+     * @dev get the amount of pool tokens to mint for the caller
+     * and the amount of reserve tokens to transfer from the caller
+     *
+     * @param _reserveAmounts   amount of each reserve token
+     * @param _reserveBalances  balance of each reserve token
+     * @param _totalSupply      total supply of pool tokens
+     *
+     * @return amount of pool tokens to mint for the caller
+     * @return amount of reserve tokens to transfer from the caller
+     */
+    function addLiquidityAmounts(
+        IERC20[2] memory, /* _reserveTokens */
+        uint256[2] memory _reserveAmounts,
+        uint256[2] memory _reserveBalances,
+        uint256 _totalSupply
+    ) internal view virtual returns (uint256, uint256[2] memory) {
+        this;
+
+        uint256 index =
+            _reserveAmounts[0].mul(_reserveBalances[1]) < _reserveAmounts[1].mul(_reserveBalances[0]) ? 0 : 1;
+        uint256 amount = fundSupplyAmount(_totalSupply, _reserveBalances[index], _reserveAmounts[index]);
+
+        uint256[2] memory reserveAmounts = [
+            fundCost(_totalSupply, _reserveBalances[0], amount),
+            fundCost(_totalSupply, _reserveBalances[1], amount)
+        ];
+
+        return (amount, reserveAmounts);
+    }
+
+    /**
      * @dev decreases the pool's liquidity and burns the caller's shares in the pool
      * this version receives the two minimum return amounts as separate args
      *
@@ -969,25 +1004,25 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
      * since an empty pool can be funded with any list of non-zero input amounts,
      * this function assumes that the pool is not empty (has already been funded)
      *
-     * @param _reserveTokenIndex the index of the relevant reserve token
-     * @param _reserveAmount the amount of the relevant reserve token
+     * @param _reserveTokens       address of each reserve token
+     * @param _reserveTokenIndex   index of the relevant reserve token
+     * @param _reserveAmount       amount of the relevant reserve token
      *
-     * @return the required amount of the 1st reserve token
-     * @return the required amount of the 2nd reserve token
+     * @return the required amount of each one of the reserve tokens
      */
-    function addLiquidityCost(uint256 _reserveTokenIndex, uint256 _reserveAmount)
-        public
-        view
-        returns (uint256, uint256)
-    {
+    function addLiquidityCost(
+        IERC20[2] memory _reserveTokens,
+        uint256 _reserveTokenIndex,
+        uint256 _reserveAmount
+    ) public view returns (uint256[2] memory) {
         uint256 totalSupply = IDSToken(address(anchor)).totalSupply();
-        uint256[2] memory baseBalances = reserveBalancesArray();
+        uint256[2] memory baseBalances = baseReserveBalances(_reserveTokens);
         uint256 amount = fundSupplyAmount(totalSupply, baseBalances[_reserveTokenIndex], _reserveAmount);
 
-        return (
+        return [
             fundCost(totalSupply, baseBalances[0], amount),
             fundCost(totalSupply, baseBalances[1], amount)
-        );
+        ];
     }
 
     /**
@@ -995,40 +1030,37 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
      * since an empty pool can be funded with any list of non-zero input amounts,
      * this function assumes that the pool is not empty (has already been funded)
      *
-     * @param _reserve1Amount the amount of the 1st reserve token
-     * @param _reserve2Amount the amount of the 2nd reserve token
+     * @param _reserveTokens   address of each reserve token
+     * @param _reserveAmounts  amount of each reserve token
      *
      * @return the amount of pool tokens entitled for the given amounts of reserve tokens
      */
-    function addLiquidityReturn(uint256 _reserve1Amount, uint256 _reserve2Amount)
-        public
-        view
-        returns (uint256)
-    {
+    function addLiquidityReturn(
+        IERC20[2] memory _reserveTokens,
+        uint256[2] memory _reserveAmounts
+    ) public view returns (uint256) {
         uint256 totalSupply = IDSToken(address(anchor)).totalSupply();
-        uint256[2] memory baseBalances = reserveBalancesArray();
-        uint256[2] memory reserveAmounts = [_reserve1Amount, _reserve2Amount];
-        (uint256 amount, ) = addLiquidityAmounts(__reserveTokens, reserveAmounts, baseBalances, totalSupply);
+        uint256[2] memory baseBalances = baseReserveBalances(_reserveTokens);
+        (uint256 amount, ) = addLiquidityAmounts(_reserveTokens, _reserveAmounts, baseBalances, totalSupply);
         return amount;
     }
 
     /**
      * @dev returns the amount of each reserve token entitled for a given amount of pool tokens
      *
-     * @param _amount the amount of pool tokens
+     * @param _amount          amount of pool tokens
+     * @param _reserveTokens   address of each reserve token
      *
-     * @return the amount of the 1st reserves token entitled for the given amount of pool tokens
-     * @return the amount of the 2nd reserves token entitled for the given amount of pool tokens
+     * @return the amount of each reserve token entitled for the given amount of pool tokens
      */
-    function removeLiquidityReturn(uint256 _amount)
+    function removeLiquidityReturn(uint256 _amount, IERC20[2] memory _reserveTokens)
         public
         view
-        returns (uint256, uint256)
+        returns (uint256[2] memory)
     {
         uint256 totalSupply = IDSToken(address(anchor)).totalSupply();
-        uint256[2] memory baseBalances = reserveBalancesArray();
-        uint256[2] memory reserveAmounts = removeLiquidityReserveAmounts(_amount, totalSupply, baseBalances);
-        return (reserveAmounts[0], reserveAmounts[1]);
+        uint256[2] memory baseBalances = baseReserveBalances(_reserveTokens);
+        return removeLiquidityReserveAmounts(_amount, totalSupply, baseBalances);
     }
 
     /**
@@ -1075,37 +1107,6 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
      */
     function validReserveAmounts(uint256[2] memory _reserveAmounts) internal pure virtual returns (bool) {
         return _reserveAmounts[0] > 0 && _reserveAmounts[1] > 0;
-    }
-
-    /**
-     * @dev get the amount of pool tokens to mint for the caller
-     * and the amount of reserve tokens to transfer from the caller
-     *
-     * @param _reserveAmounts   amount of each reserve token
-     * @param _reserveBalances  balance of each reserve token
-     * @param _totalSupply      total supply of pool tokens
-     *
-     * @return amount of pool tokens to mint for the caller
-     * @return amount of reserve tokens to transfer from the caller
-     */
-    function addLiquidityAmounts(
-        IERC20[2] memory, /* _reserveTokens */
-        uint256[2] memory _reserveAmounts,
-        uint256[2] memory _reserveBalances,
-        uint256 _totalSupply
-    ) internal view virtual returns (uint256, uint256[2] memory) {
-        this;
-
-        uint256 index =
-            _reserveAmounts[0].mul(_reserveBalances[1]) < _reserveAmounts[1].mul(_reserveBalances[0]) ? 0 : 1;
-        uint256 amount = fundSupplyAmount(_totalSupply, _reserveBalances[index], _reserveAmounts[index]);
-
-        uint256[2] memory reserveAmounts = [
-            fundCost(_totalSupply, _reserveBalances[0], amount),
-            fundCost(_totalSupply, _reserveBalances[1], amount)
-        ];
-
-        return (amount, reserveAmounts);
     }
 
     /**

--- a/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
+++ b/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
@@ -233,7 +233,7 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
         ownerOnly
         only(CONVERTER_UPGRADER)
     {
-        uint256 reserveCount = __reserveTokens.length;
+        uint256 reserveCount = __reserveTokensCount;
         for (uint256 i = 0; i < reserveCount; ++i) {
             IERC20 reserveToken = __reserveTokens[i];
 

--- a/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
+++ b/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
@@ -855,37 +855,6 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
     }
 
     /**
-     * @dev get the amount of pool tokens to mint for the caller
-     * and the amount of reserve tokens to transfer from the caller
-     *
-     * @param _reserveAmounts   amount of each reserve token
-     * @param _reserveBalances  balance of each reserve token
-     * @param _totalSupply      total supply of pool tokens
-     *
-     * @return amount of pool tokens to mint for the caller
-     * @return amount of reserve tokens to transfer from the caller
-     */
-    function addLiquidityAmounts(
-        IERC20[2] memory, /* _reserveTokens */
-        uint256[2] memory _reserveAmounts,
-        uint256[2] memory _reserveBalances,
-        uint256 _totalSupply
-    ) internal view virtual returns (uint256, uint256[2] memory) {
-        this;
-
-        uint256 index =
-            _reserveAmounts[0].mul(_reserveBalances[1]) < _reserveAmounts[1].mul(_reserveBalances[0]) ? 0 : 1;
-        uint256 amount = fundSupplyAmount(_totalSupply, _reserveBalances[index], _reserveAmounts[index]);
-
-        uint256[2] memory reserveAmounts = [
-            fundCost(_totalSupply, _reserveBalances[0], amount),
-            fundCost(_totalSupply, _reserveBalances[1], amount)
-        ];
-
-        return (amount, reserveAmounts);
-    }
-
-    /**
      * @dev decreases the pool's liquidity and burns the caller's shares in the pool
      * this version receives the two minimum return amounts as separate args
      *
@@ -1107,6 +1076,37 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
      */
     function validReserveAmounts(uint256[2] memory _reserveAmounts) internal pure virtual returns (bool) {
         return _reserveAmounts[0] > 0 && _reserveAmounts[1] > 0;
+    }
+
+    /**
+     * @dev get the amount of pool tokens to mint for the caller
+     * and the amount of reserve tokens to transfer from the caller
+     *
+     * @param _reserveAmounts   amount of each reserve token
+     * @param _reserveBalances  balance of each reserve token
+     * @param _totalSupply      total supply of pool tokens
+     *
+     * @return amount of pool tokens to mint for the caller
+     * @return amount of reserve tokens to transfer from the caller
+     */
+    function addLiquidityAmounts(
+        IERC20[2] memory, /* _reserveTokens */
+        uint256[2] memory _reserveAmounts,
+        uint256[2] memory _reserveBalances,
+        uint256 _totalSupply
+    ) internal view virtual returns (uint256, uint256[2] memory) {
+        this;
+
+        uint256 index =
+            _reserveAmounts[0].mul(_reserveBalances[1]) < _reserveAmounts[1].mul(_reserveBalances[0]) ? 0 : 1;
+        uint256 amount = fundSupplyAmount(_totalSupply, _reserveBalances[index], _reserveAmounts[index]);
+
+        uint256[2] memory reserveAmounts = [
+            fundCost(_totalSupply, _reserveBalances[0], amount),
+            fundCost(_totalSupply, _reserveBalances[1], amount)
+        ];
+
+        return (amount, reserveAmounts);
     }
 
     /**

--- a/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
+++ b/solidity/contracts/converter/types/standard-pool/StandardPoolConverter.sol
@@ -233,7 +233,7 @@ contract StandardPoolConverter is ConverterVersion, IConverter, ContractRegistry
         ownerOnly
         only(CONVERTER_UPGRADER)
     {
-        uint256 reserveCount = __reserveTokensCount;
+        uint256 reserveCount = _reserveTokensCount;
         for (uint256 i = 0; i < reserveCount; ++i) {
             IERC20 reserveToken = __reserveTokens[i];
 

--- a/solidity/contracts/helpers/TestFixedRatePoolConverter.sol
+++ b/solidity/contracts/helpers/TestFixedRatePoolConverter.sol
@@ -5,7 +5,7 @@ import "../converter/types/fixed-rate-pool/FixedRatePoolConverter.sol";
 import "./TestTime.sol";
 
 contract TestFixedRatePoolConverter is FixedRatePoolConverter, TestTime {
-    uint256[] public reserveAmountsRemoved = new uint256[](2);
+    uint256[2] public reserveAmountsRemoved;
 
     constructor(
         IDSToken _token,
@@ -15,8 +15,8 @@ contract TestFixedRatePoolConverter is FixedRatePoolConverter, TestTime {
 
     function removeLiquidityTest(
         uint256 _amount,
-        IERC20[] memory _reserveTokens,
-        uint256[] memory _reserveMinReturnAmounts
+        IERC20[2] memory _reserveTokens,
+        uint256[2] memory _reserveMinReturnAmounts
     ) public {
         reserveAmountsRemoved = removeLiquidity(_amount, _reserveTokens, _reserveMinReturnAmounts);
     }

--- a/solidity/contracts/helpers/TestStandardPoolConverter.sol
+++ b/solidity/contracts/helpers/TestStandardPoolConverter.sol
@@ -5,7 +5,7 @@ import "../converter/types/standard-pool/StandardPoolConverter.sol";
 import "./TestTime.sol";
 
 contract TestStandardPoolConverter is StandardPoolConverter, TestTime {
-    uint256[] public reserveAmountsRemoved = new uint256[](2);
+    uint256[2] public reserveAmountsRemoved;
 
     constructor(
         IDSToken _token,
@@ -15,8 +15,8 @@ contract TestStandardPoolConverter is StandardPoolConverter, TestTime {
 
     function removeLiquidityTest(
         uint256 _amount,
-        IERC20[] memory _reserveTokens,
-        uint256[] memory _reserveMinReturnAmounts
+        IERC20[2] memory _reserveTokens,
+        uint256[2] memory _reserveMinReturnAmounts
     ) public {
         reserveAmountsRemoved = removeLiquidity(_amount, _reserveTokens, _reserveMinReturnAmounts);
     }

--- a/solidity/test/ConverterLiquidity.js
+++ b/solidity/test/ConverterLiquidity.js
@@ -174,7 +174,7 @@ describe('ConverterLiquidity', () => {
                         reserveTokens,
                         reserveAmounts
                     );
-                    const liquidityReturns = await getLiquidityReturns(
+                    const liquidityReturn = await getLiquidityReturn(
                         state.length == 0,
                         converter,
                         reserveTokens,
@@ -207,9 +207,7 @@ describe('ConverterLiquidity', () => {
                         }
                     }
 
-                    for (const liquidityReturn of liquidityReturns) {
-                        expect(liquidityReturn).to.be.bignumber.equal(supply.sub(prevSupply));
-                    }
+                    expect(liquidityReturn).to.be.bignumber.equal(supply.sub(prevSupply));
 
                     expected = actual;
                     prevSupply = supply;
@@ -312,17 +310,14 @@ describe('ConverterLiquidity', () => {
         );
     };
 
-    const getLiquidityReturns = async (firstTime, converter, reserveTokens, reserveAmounts) => {
+    const getLiquidityReturn = async (firstTime, converter, reserveTokens, reserveAmounts) => {
         if (firstTime) {
             const length = Math.round(
                 reserveAmounts.map((reserveAmount) => reserveAmount.toString()).join('').length / reserveAmounts.length
             );
-            const retVal = new BN('1'.padEnd(length, '0'));
-            return reserveAmounts.map((reserveAmount, i) => retVal);
+            return new BN(10).pow(new BN(length - 1));
         }
 
-        return await Promise.all(
-            reserveAmounts.map((reserveAmount, i) => converter.addLiquidityReturn(reserveTokens[i], reserveAmount))
-        );
+        return await converter.addLiquidityReturn(reserveTokens, reserveAmounts);
     };
 });

--- a/solidity/test/FixedRatePoolConverter.js
+++ b/solidity/test/FixedRatePoolConverter.js
@@ -160,7 +160,7 @@ describe('FixedRatePoolConverter', () => {
         await reserveToken.approve(converter.address, value, { from: sender });
         await reserveToken2.approve(converter.address, value, { from: sender });
 
-        const res = await converter.addLiquidity(
+        const res = await converter.methods['addLiquidity(address[],uint256[],uint256)'](
             [reserveToken.address, reserveToken2.address],
             [value, value],
             MIN_RETURN
@@ -188,7 +188,7 @@ describe('FixedRatePoolConverter', () => {
     it('verifies the TokenRateUpdate event after removing liquidity', async () => {
         const converter = await initConverter(true, false);
 
-        const res = await converter.removeLiquidity(
+        const res = await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
             100,
             [reserveToken.address, reserveToken2.address],
             [MIN_RETURN, MIN_RETURN]
@@ -357,7 +357,7 @@ describe('FixedRatePoolConverter', () => {
                 }
 
                 await reserveToken2.approve(converter.address, amount, { from: sender2 });
-                await converter.addLiquidity(
+                await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                     [getReserve1Address(isETHReserve), reserveToken2.address],
                     [amount, token2Amount],
                     1,
@@ -395,7 +395,7 @@ describe('FixedRatePoolConverter', () => {
                 }
 
                 await reserveToken2.approve(converter.address, amount, { from: sender2 });
-                await converter.addLiquidity(
+                await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                     [getReserve1Address(isETHReserve), reserveToken2.address],
                     [amount, token2Amount],
                     1,
@@ -427,7 +427,7 @@ describe('FixedRatePoolConverter', () => {
                 }
 
                 await reserveToken2.approve(converter.address, amount, { from: sender2 });
-                await converter.addLiquidity(
+                await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                     [getReserve1Address(isETHReserve), reserveToken2.address],
                     [amount, 10],
                     1,
@@ -435,7 +435,7 @@ describe('FixedRatePoolConverter', () => {
                 );
 
                 await expectRevert.unspecified(
-                    converter.addLiquidity(
+                    converter.methods['addLiquidity(address[],uint256[],uint256)'](
                         [getReserve1Address(isETHReserve), reserveToken2.address],
                         [amount, 1000],
                         1,
@@ -497,7 +497,7 @@ describe('FixedRatePoolConverter', () => {
 
                 const token1PrevBalance = await getBalance(reserveToken, getReserve1Address(isETHReserve), sender2);
                 const token2PrevBalance = await reserveToken2.balanceOf.call(sender2);
-                const res = await converter.removeLiquidity(
+                const res = await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                     19,
                     [getReserve1Address(isETHReserve), reserveToken2.address],
                     [1, 1],
@@ -534,7 +534,7 @@ describe('FixedRatePoolConverter', () => {
                 const token1PrevBalance = await getBalance(reserveToken, getReserve1Address(isETHReserve), sender2);
                 const token2PrevBalance = await reserveToken2.balanceOf.call(sender2);
 
-                const res = await converter.removeLiquidity(
+                const res = await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                     14854,
                     [getReserve1Address(isETHReserve), reserveToken2.address],
                     [1, 1],
@@ -566,7 +566,7 @@ describe('FixedRatePoolConverter', () => {
 
                 const token1PrevBalance = await getBalance(reserveToken, getReserve1Address(isETHReserve), sender2);
                 const token2PrevBalance = await reserveToken2.balanceOf.call(sender2);
-                const res = await converter.removeLiquidity(
+                const res = await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                     20000,
                     [getReserve1Address(isETHReserve), reserveToken2.address],
                     [1, 1],
@@ -597,12 +597,12 @@ describe('FixedRatePoolConverter', () => {
 
                 await token.transfer(sender2, 100);
 
-                await converter.removeLiquidity(5, [getReserve1Address(isETHReserve), reserveToken2.address], [1, 1], {
+                await converter.methods['removeLiquidity(uint256,address[],uint256[])'](5, [getReserve1Address(isETHReserve), reserveToken2.address], [1, 1], {
                     from: sender2
                 });
 
                 await expectRevert.unspecified(
-                    converter.removeLiquidity(600, [getReserve1Address(isETHReserve), reserveToken2.address], [1, 1], {
+                    converter.methods['removeLiquidity(uint256,address[],uint256[])'](600, [getReserve1Address(isETHReserve), reserveToken2.address], [1, 1], {
                         from: sender2
                     })
                 );
@@ -675,7 +675,7 @@ describe('FixedRatePoolConverter', () => {
                     it(`addLiquidity(${[amount1, amount2]})`, async () => {
                         await reserveToken1.approve(converter.address, amount1, { from: sender });
                         await reserveToken2.approve(converter.address, amount2, { from: sender });
-                        await converter.addLiquidity(
+                        await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                             [reserveToken1.address, reserveToken2.address],
                             [amount1, amount2],
                             1
@@ -725,7 +725,7 @@ describe('FixedRatePoolConverter', () => {
                                 await reserveToken2.transfer(sender2, amount, { from: sender });
                                 await reserveToken1.approve(converter.address, amount, { from: sender2 });
                                 await reserveToken2.approve(converter.address, amount, { from: sender2 });
-                                await converter.addLiquidity(
+                                await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                                     [reserveToken1.address, reserveToken2.address],
                                     [amount, amount],
                                     MIN_RETURN,
@@ -735,7 +735,7 @@ describe('FixedRatePoolConverter', () => {
                                 lastAmount = balance.sub(lastAmount);
                             }
                             for (const percent of percents) {
-                                await converter.removeLiquidity(
+                                await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                                     lastAmount.mul(new BN(percent)).div(new BN(100)),
                                     [reserveToken1.address, reserveToken2.address],
                                     [MIN_RETURN, MIN_RETURN],
@@ -1015,19 +1015,16 @@ describe('FixedRatePoolConverter', () => {
             );
         };
 
-        const getLiquidityReturns = async (firstTime, converter, reserveTokens, reserveAmounts) => {
+        const getLiquidityReturn = async (firstTime, converter, reserveTokens, reserveAmounts) => {
             if (firstTime) {
                 const length = Math.round(
                     reserveAmounts.map((reserveAmount) => reserveAmount.toString()).join('').length /
                         reserveAmounts.length
                 );
-                const retVal = new BN('1'.padEnd(length, '0'));
-                return reserveAmounts.map((reserveAmount, i) => retVal);
+                return new BN(10).pow(new BN(length - 1));
             }
 
-            return await Promise.all(
-                reserveAmounts.map((reserveAmount, i) => converter.addLiquidityReturn(reserveTokens[i], reserveAmount))
-            );
+            return await converter.addLiquidityReturn(reserveTokens, reserveAmounts);
         };
 
         const test = async (hasETH, rateN, rateD) => {
@@ -1058,13 +1055,13 @@ describe('FixedRatePoolConverter', () => {
                     reserveTokens,
                     reserveAmounts
                 );
-                const liquidityReturns = await getLiquidityReturns(
+                const liquidityReturn = await getLiquidityReturn(
                     state.length == 0,
                     converter,
                     reserveTokens,
                     reserveAmounts
                 );
-                await converter.addLiquidity(reserveTokens, reserveAmounts, MIN_RETURN, {
+                await converter.methods['addLiquidity(address[],uint256[],uint256)'](reserveTokens, reserveAmounts, MIN_RETURN, {
                     value: hasETH ? reserveAmounts.slice(-1)[0] : 0
                 });
                 const allowances = await Promise.all(
@@ -1091,9 +1088,7 @@ describe('FixedRatePoolConverter', () => {
                     }
                 }
 
-                for (const liquidityReturn of liquidityReturns) {
-                    expect(liquidityReturn).to.be.bignumber.equal(supply.sub(prevSupply));
-                }
+                expect(liquidityReturn).to.be.bignumber.equal(supply.sub(prevSupply));
 
                 expected = actual;
                 prevSupply = supply;
@@ -1103,7 +1098,7 @@ describe('FixedRatePoolConverter', () => {
             for (let n = state.length - 1; n > 0; n--) {
                 const supplyAmount = state[n].supply.sub(new BN(state[n - 1].supply));
                 const reserveAmounts = await converter.removeLiquidityReturn(supplyAmount, reserveTokens);
-                await converter.removeLiquidity(
+                await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                     supplyAmount,
                     reserveTokens,
                     reserveTokens.map((reserveTokens) => 1)
@@ -1121,7 +1116,7 @@ describe('FixedRatePoolConverter', () => {
 
             const supplyAmount = state[0].supply;
             const reserveAmounts = await converter.removeLiquidityReturn(supplyAmount, reserveTokens);
-            await converter.removeLiquidity(
+            await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                 supplyAmount,
                 reserveTokens,
                 reserveTokens.map((reserveTokens) => 1)

--- a/solidity/test/LiquidityPoolV1Converter.js
+++ b/solidity/test/LiquidityPoolV1Converter.js
@@ -992,19 +992,16 @@ describe('LiquidityPoolV1Converter', () => {
             );
         };
 
-        const getLiquidityReturns = async (firstTime, converter, reserveTokens, reserveAmounts) => {
+        const getLiquidityReturn = async (firstTime, converter, reserveTokens, reserveAmounts) => {
             if (firstTime) {
                 const length = Math.round(
                     reserveAmounts.map((reserveAmount) => reserveAmount.toString()).join('').length /
                         reserveAmounts.length
                 );
-                const retVal = new BN('1'.padEnd(length, '0'));
-                return reserveAmounts.map((reserveAmount, i) => retVal);
+                return new BN(10).pow(new BN(length - 1));
             }
 
-            return await Promise.all(
-                reserveAmounts.map((reserveAmount, i) => converter.addLiquidityReturn(reserveTokens[i], reserveAmount))
-            );
+            return await converter.addLiquidityReturn(reserveTokens, reserveAmounts);
         };
 
         const test = async (hasETH) => {
@@ -1035,7 +1032,7 @@ describe('LiquidityPoolV1Converter', () => {
                     reserveTokens,
                     reserveAmounts
                 );
-                const liquidityReturns = await getLiquidityReturns(
+                const liquidityReturn = await getLiquidityReturn(
                     state.length == 0,
                     converter,
                     reserveTokens,
@@ -1068,9 +1065,7 @@ describe('LiquidityPoolV1Converter', () => {
                     }
                 }
 
-                for (const liquidityReturn of liquidityReturns) {
-                    expect(liquidityReturn).to.be.bignumber.equal(supply.sub(prevSupply));
-                }
+                expect(liquidityReturn).to.be.bignumber.equal(supply.sub(prevSupply));
 
                 expected = actual;
                 prevSupply = supply;

--- a/solidity/test/LiquidityProtection.js
+++ b/solidity/test/LiquidityProtection.js
@@ -98,7 +98,7 @@ describe('LiquidityProtection', () => {
                     await baseToken.approve(converter.address, RESERVE1_AMOUNT);
                 }
 
-                await converter.addLiquidity(
+                await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                     [baseTokenAddress, networkToken.address],
                     [RESERVE1_AMOUNT, RESERVE2_AMOUNT],
                     1,
@@ -478,7 +478,7 @@ describe('LiquidityProtection', () => {
                 it(`pool available space with additional balances of ${baseBalance} and ${networkBalance}`, async () => {
                     await baseToken.approve(converter.address, baseBalance);
                     await networkToken.approve(converter.address, networkBalance);
-                    await converter.addLiquidity(
+                    await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                         [baseToken.address, networkToken.address],
                         [baseBalance, networkBalance],
                         1

--- a/solidity/test/LiquidityProtectionAverageRate.js
+++ b/solidity/test/LiquidityProtectionAverageRate.js
@@ -170,7 +170,7 @@ describe('LiquidityProtectionAverageRate', () => {
                             );
                             await reserveToken1.approve(converter.address, INITIAL_AMOUNT);
                             await reserveToken2.approve(converter.address, INITIAL_AMOUNT);
-                            await converter.addLiquidity(
+                            await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                                 [reserveToken1.address, reserveToken2.address],
                                 [INITIAL_AMOUNT, INITIAL_AMOUNT],
                                 1
@@ -206,7 +206,7 @@ describe('LiquidityProtectionAverageRate', () => {
                                     'ERR_INVALID_RATE'
                                 );
                             }
-                            await converter.removeLiquidity(
+                            await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                                 await poolToken.balanceOf(defaultSender),
                                 [reserveToken1.address, reserveToken2.address],
                                 [1, 1]

--- a/solidity/test/LiquidityProtectionEdgeCases.js
+++ b/solidity/test/LiquidityProtectionEdgeCases.js
@@ -278,7 +278,7 @@ describe('LiquidityProtectionEdgeCases', () => {
                         it(`base token, increaseRate = ${config.increaseRate}, generateFee = ${config.generateFee}, numOfDays = ${numOfDays}, decimals = ${decimals}`, async () => {
                             await baseToken.approve(converter.address, amounts[0]);
                             await networkToken.approve(converter.address, amounts[1]);
-                            await converter.addLiquidity(
+                            await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                                 [baseToken.address, networkToken.address],
                                 [amounts[0], amounts[1]],
                                 1
@@ -352,7 +352,7 @@ describe('LiquidityProtectionEdgeCases', () => {
                         it(`network token, increaseRate = ${config.increaseRate}, generateFee = ${config.generateFee}, numOfDays = ${numOfDays}, decimals = ${decimals}`, async () => {
                             await baseToken.approve(converter.address, amounts[0]);
                             await networkToken.approve(converter.address, amounts[1]);
-                            await converter.addLiquidity(
+                            await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                                 [baseToken.address, networkToken.address],
                                 [amounts[0], amounts[1]],
                                 1

--- a/solidity/test/StandardPoolConverter.js
+++ b/solidity/test/StandardPoolConverter.js
@@ -166,7 +166,7 @@ describe('StandardPoolConverter', () => {
         await reserveToken.approve(converter.address, value, { from: sender });
         await reserveToken2.approve(converter.address, value, { from: sender });
 
-        const res = await converter.addLiquidity(
+        const res = await converter.methods['addLiquidity(address[],uint256[],uint256)'](
             [reserveToken.address, reserveToken2.address],
             [value, value],
             MIN_RETURN
@@ -194,7 +194,7 @@ describe('StandardPoolConverter', () => {
     it('verifies the TokenRateUpdate event after removing liquidity', async () => {
         const converter = await initConverter(true, false);
 
-        const res = await converter.removeLiquidity(
+        const res = await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
             100,
             [reserveToken.address, reserveToken2.address],
             [MIN_RETURN, MIN_RETURN]
@@ -418,7 +418,7 @@ describe('StandardPoolConverter', () => {
                 }
 
                 await reserveToken2.approve(converter.address, amount, { from: sender2 });
-                await converter.addLiquidity(
+                await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                     [getReserve1Address(isETHReserve), reserveToken2.address],
                     [amount, token2Amount],
                     1,
@@ -457,7 +457,7 @@ describe('StandardPoolConverter', () => {
                 }
 
                 await reserveToken2.approve(converter.address, amount, { from: sender2 });
-                await converter.addLiquidity(
+                await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                     [getReserve1Address(isETHReserve), reserveToken2.address],
                     [amount, token2Amount],
                     1,
@@ -489,7 +489,7 @@ describe('StandardPoolConverter', () => {
                 }
 
                 await reserveToken2.approve(converter.address, amount, { from: sender2 });
-                await converter.addLiquidity(
+                await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                     [getReserve1Address(isETHReserve), reserveToken2.address],
                     [amount, 10],
                     1,
@@ -497,7 +497,7 @@ describe('StandardPoolConverter', () => {
                 );
 
                 await expectRevert.unspecified(
-                    converter.addLiquidity(
+                    converter.methods['addLiquidity(address[],uint256[],uint256)'](
                         [getReserve1Address(isETHReserve), reserveToken2.address],
                         [amount, 1000],
                         1,
@@ -560,7 +560,7 @@ describe('StandardPoolConverter', () => {
 
                 const token1PrevBalance = await getBalance(reserveToken, getReserve1Address(isETHReserve), sender2);
                 const token2PrevBalance = await reserveToken2.balanceOf.call(sender2);
-                const res = await converter.removeLiquidity(
+                const res = await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                     19,
                     [getReserve1Address(isETHReserve), reserveToken2.address],
                     [1, 1],
@@ -597,7 +597,7 @@ describe('StandardPoolConverter', () => {
                 const token1PrevBalance = await getBalance(reserveToken, getReserve1Address(isETHReserve), sender2);
                 const token2PrevBalance = await reserveToken2.balanceOf.call(sender2);
 
-                const res = await converter.removeLiquidity(
+                const res = await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                     14854,
                     [getReserve1Address(isETHReserve), reserveToken2.address],
                     [1, 1],
@@ -629,7 +629,7 @@ describe('StandardPoolConverter', () => {
 
                 const token1PrevBalance = await getBalance(reserveToken, getReserve1Address(isETHReserve), sender2);
                 const token2PrevBalance = await reserveToken2.balanceOf.call(sender2);
-                const res = await converter.removeLiquidity(
+                const res = await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                     20000,
                     [getReserve1Address(isETHReserve), reserveToken2.address],
                     [1, 1],
@@ -660,12 +660,12 @@ describe('StandardPoolConverter', () => {
 
                 await token.transfer(sender2, 100);
 
-                await converter.removeLiquidity(5, [getReserve1Address(isETHReserve), reserveToken2.address], [1, 1], {
+                await converter.methods['removeLiquidity(uint256,address[],uint256[])'](5, [getReserve1Address(isETHReserve), reserveToken2.address], [1, 1], {
                     from: sender2
                 });
 
                 await expectRevert.unspecified(
-                    converter.removeLiquidity(600, [getReserve1Address(isETHReserve), reserveToken2.address], [1, 1], {
+                    converter.methods['removeLiquidity(uint256,address[],uint256[])'](600, [getReserve1Address(isETHReserve), reserveToken2.address], [1, 1], {
                         from: sender2
                     })
                 );
@@ -735,7 +735,7 @@ describe('StandardPoolConverter', () => {
             it(`addLiquidity(${[amount1, amount2]})`, async () => {
                 await reserveToken1.approve(converter.address, amount1, { from: sender });
                 await reserveToken2.approve(converter.address, amount2, { from: sender });
-                await converter.addLiquidity([reserveToken1.address, reserveToken2.address], [amount1, amount2], 1);
+                await converter.methods['addLiquidity(address[],uint256[],uint256)']([reserveToken1.address, reserveToken2.address], [amount1, amount2], 1);
                 const balance1 = await reserveToken1.balanceOf.call(converter.address);
                 const balance2 = await reserveToken2.balanceOf.call(converter.address);
                 const a1b2 = new BN(amount1).mul(balance2);
@@ -776,7 +776,7 @@ describe('StandardPoolConverter', () => {
                         await reserveToken2.transfer(sender2, amount, { from: sender });
                         await reserveToken1.approve(converter.address, amount, { from: sender2 });
                         await reserveToken2.approve(converter.address, amount, { from: sender2 });
-                        await converter.addLiquidity(
+                        await converter.methods['addLiquidity(address[],uint256[],uint256)'](
                             [reserveToken1.address, reserveToken2.address],
                             [amount, amount],
                             MIN_RETURN,
@@ -786,7 +786,7 @@ describe('StandardPoolConverter', () => {
                         lastAmount = balance.sub(lastAmount);
                     }
                     for (const percent of percents) {
-                        await converter.removeLiquidity(
+                        await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                             lastAmount.mul(new BN(percent)).div(new BN(100)),
                             [reserveToken1.address, reserveToken2.address],
                             [MIN_RETURN, MIN_RETURN],
@@ -1062,19 +1062,16 @@ describe('StandardPoolConverter', () => {
             );
         };
 
-        const getLiquidityReturns = async (firstTime, converter, reserveTokens, reserveAmounts) => {
+        const getLiquidityReturn = async (firstTime, converter, reserveTokens, reserveAmounts) => {
             if (firstTime) {
                 const length = Math.round(
                     reserveAmounts.map((reserveAmount) => reserveAmount.toString()).join('').length /
                         reserveAmounts.length
                 );
-                const retVal = new BN('1'.padEnd(length, '0'));
-                return reserveAmounts.map((reserveAmount, i) => retVal);
+                return new BN(10).pow(new BN(length - 1));
             }
 
-            return await Promise.all(
-                reserveAmounts.map((reserveAmount, i) => converter.addLiquidityReturn(reserveTokens[i], reserveAmount))
-            );
+            return await converter.addLiquidityReturn(reserveTokens, reserveAmounts);
         };
 
         const test = async (hasETH) => {
@@ -1105,13 +1102,13 @@ describe('StandardPoolConverter', () => {
                     reserveTokens,
                     reserveAmounts
                 );
-                const liquidityReturns = await getLiquidityReturns(
+                const liquidityReturn = await getLiquidityReturn(
                     state.length == 0,
                     converter,
                     reserveTokens,
                     reserveAmounts
                 );
-                await converter.addLiquidity(reserveTokens, reserveAmounts, MIN_RETURN, {
+                await converter.methods['addLiquidity(address[],uint256[],uint256)'](reserveTokens, reserveAmounts, MIN_RETURN, {
                     value: hasETH ? reserveAmounts.slice(-1)[0] : 0
                 });
                 const allowances = await Promise.all(
@@ -1126,21 +1123,19 @@ describe('StandardPoolConverter', () => {
 
                 for (let i = 0; i < allowances.length; i++) {
                     const diff = Decimal(allowances[i].toString()).div(reserveAmounts[i].toString());
-                    expect(diff.eq('0')).to.be.true();
+                    expect(diff.toFixed()).to.be.equal('0');
                 }
 
                 const actual = balances.map((balance) => Decimal(balance.toString()).div(supply.toString()));
                 for (let i = 0; i < expected.length; i++) {
                     const diff = expected[i].div(actual[i]);
-                    expect(diff.eq('1')).to.be.true();
+                    expect(diff.toFixed()).to.be.equal('1');
                     for (const liquidityCost of liquidityCosts) {
                         expect(liquidityCost[i]).to.be.bignumber.equal(balances[i].sub(prevBalances[i]));
                     }
                 }
 
-                for (const liquidityReturn of liquidityReturns) {
-                    expect(liquidityReturn).to.be.bignumber.equal(supply.sub(prevSupply));
-                }
+                expect(liquidityReturn).to.be.bignumber.equal(supply.sub(prevSupply));
 
                 expected = actual;
                 prevSupply = supply;
@@ -1150,7 +1145,7 @@ describe('StandardPoolConverter', () => {
             for (let n = state.length - 1; n > 0; n--) {
                 const supplyAmount = state[n].supply.sub(new BN(state[n - 1].supply));
                 const reserveAmounts = await converter.removeLiquidityReturn(supplyAmount, reserveTokens);
-                await converter.removeLiquidity(
+                await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                     supplyAmount,
                     reserveTokens,
                     reserveTokens.map((reserveTokens) => 1)
@@ -1160,7 +1155,7 @@ describe('StandardPoolConverter', () => {
                 );
                 for (let i = 0; i < balances.length; i++) {
                     const diff = Decimal(state[n - 1].balances[i].toString()).div(Decimal(balances[i].toString()));
-                    expect(diff.eq('1')).to.be.true();
+                    expect(diff.toFixed()).to.be.equal('1');
                     expect(prevBalances[i].sub(balances[i])).to.be.bignumber.equal(reserveAmounts[i]);
                 }
                 prevBalances = balances;
@@ -1168,7 +1163,7 @@ describe('StandardPoolConverter', () => {
 
             const supplyAmount = state[0].supply;
             const reserveAmounts = await converter.removeLiquidityReturn(supplyAmount, reserveTokens);
-            await converter.removeLiquidity(
+            await converter.methods['removeLiquidity(uint256,address[],uint256[])'](
                 supplyAmount,
                 reserveTokens,
                 reserveTokens.map((reserveTokens) => 1)


### PR DESCRIPTION
1. Change dynamic arrays to static arrays in the Standard-Pool converter.
2. Fix the prototype of function `addLiquidityReturn` in all converter types.

The goals of the 2nd bullet are:
- Provide a function which takes the same input as that of function `addLiquidity` (at present, users need to call the function for each reserve amount, and then choose the smallest returned value).
- Allow code reuse in the "future" network-fee mechanism.
