### PR TITLE
Refactor LiquidityProtection

### DIFF
--- a/solidity/contracts/helpers/TestLiquidityProtection.sol
+++ b/solidity/contracts/helpers/TestLiquidityProtection.sol
@@ -9,7 +9,28 @@ contract TestLiquidityProtection is LiquidityProtection, TestTime {
     uint256 private poolTokenRateN;
     uint256 private poolTokenRateD;
 
-    constructor(address[8] memory _contractAddresses) public LiquidityProtection(_contractAddresses) {}
+    constructor(
+        ILiquidityProtectionSettings settings,
+        ILiquidityProtectionStore store,
+        ILiquidityProtectionStats stats,
+        ILiquidityProtectionSystemStore systemStore,
+        ITokenHolder wallet,
+        ITokenGovernance networkTokenGovernance,
+        ITokenGovernance govTokenGovernance,
+        ICheckpointStore lastRemoveCheckpointStore
+    )
+        public
+        LiquidityProtection(
+            settings,
+            store,
+            stats,
+            systemStore,
+            wallet,
+            networkTokenGovernance,
+            govTokenGovernance,
+            lastRemoveCheckpointStore
+        )
+    {}
 
     function protectedAmountPlusFeeTest(
         uint256 _poolAmount,

--- a/solidity/contracts/helpers/TestLiquidityProtection.sol
+++ b/solidity/contracts/helpers/TestLiquidityProtection.sol
@@ -5,9 +5,9 @@ import "../liquidity-protection/LiquidityProtection.sol";
 import "./TestTime.sol";
 
 contract TestLiquidityProtection is LiquidityProtection, TestTime {
-    bool private poolTokenRateOverride;
-    uint256 private poolTokenRateN;
-    uint256 private poolTokenRateD;
+    bool private _poolTokenRateOverride;
+    uint256 private _poolTokenRateN;
+    uint256 private _poolTokenRateD;
 
     constructor(
         ILiquidityProtectionSettings settings,
@@ -33,97 +33,97 @@ contract TestLiquidityProtection is LiquidityProtection, TestTime {
     {}
 
     function protectedAmountPlusFeeTest(
-        uint256 _poolAmount,
-        uint256 _poolRateN,
-        uint256 _poolRateD,
-        uint256 _addRateN,
-        uint256 _addRateD,
-        uint256 _removeRateN,
-        uint256 _removeRateD
+        uint256 poolAmount,
+        uint256 poolRateN,
+        uint256 poolRateD,
+        uint256 addRateN,
+        uint256 addRateD,
+        uint256 removeRateN,
+        uint256 removeRateD
     ) external pure returns (uint256) {
-        Fraction memory poolRate = Fraction({ n: _poolRateN, d: _poolRateD });
-        Fraction memory addRate = Fraction({ n: _addRateN, d: _addRateD });
-        Fraction memory removeRate = Fraction({ n: _removeRateN, d: _removeRateD });
-        return protectedAmountPlusFee(_poolAmount, poolRate, addRate, removeRate);
+        Fraction memory poolRate = Fraction({ n: poolRateN, d: poolRateD });
+        Fraction memory addRate = Fraction({ n: addRateN, d: addRateD });
+        Fraction memory removeRate = Fraction({ n: removeRateN, d: removeRateD });
+        return protectedAmountPlusFee(poolAmount, poolRate, addRate, removeRate);
     }
 
     function impLossTest(
-        uint256 _initialRateN,
-        uint256 _initialRateD,
-        uint256 _currentRateN,
-        uint256 _currentRateD
+        uint256 initialRateN,
+        uint256 initialRateD,
+        uint256 currentRateN,
+        uint256 currentRateD
     ) external pure returns (uint256, uint256) {
-        Fraction memory initialRate = Fraction({ n: _initialRateN, d: _initialRateD });
-        Fraction memory currentRate = Fraction({ n: _currentRateN, d: _currentRateD });
+        Fraction memory initialRate = Fraction({ n: initialRateN, d: initialRateD });
+        Fraction memory currentRate = Fraction({ n: currentRateN, d: currentRateD });
         Fraction memory impLossRate = impLoss(initialRate, currentRate);
         return (impLossRate.n, impLossRate.d);
     }
 
     function compensationAmountTest(
-        uint256 _amount,
-        uint256 _total,
-        uint256 _lossN,
-        uint256 _lossD,
-        uint256 _levelN,
-        uint256 _levelD
+        uint256 amount,
+        uint256 total,
+        uint256 lossN,
+        uint256 lossD,
+        uint256 levelN,
+        uint256 levelD
     ) external pure returns (uint256) {
-        Fraction memory loss = Fraction({ n: _lossN, d: _lossD });
-        Fraction memory level = Fraction({ n: _levelN, d: _levelD });
-        return compensationAmount(_amount, _total, loss, level);
+        Fraction memory loss = Fraction({ n: lossN, d: lossD });
+        Fraction memory level = Fraction({ n: levelN, d: levelD });
+        return compensationAmount(amount, total, loss, level);
     }
 
-    function averageRateTest(IDSToken _poolToken, IERC20 _reserveToken) external view returns (uint256, uint256) {
-        (, , uint256 rateN, uint256 rateD) = reserveTokenRates(_poolToken, _reserveToken, true);
+    function averageRateTest(IDSToken poolToken, IERC20 reserveToken) external view returns (uint256, uint256) {
+        (, , uint256 rateN, uint256 rateD) = reserveTokenRates(poolToken, reserveToken, true);
         return (rateN, rateD);
     }
 
     function removeLiquidityTargetAmountTest(
-        uint256 _poolTokenRateN,
-        uint256 _poolTokenRateD,
-        uint256 _poolAmount,
-        uint256 _reserveAmount,
-        uint128 _addSpotRateN,
-        uint128 _addSpotRateD,
-        uint128 _removeSpotRateN,
-        uint128 _removeSpotRateD,
-        uint128 _removeAverageRateN,
-        uint128 _removeAverageRateD,
-        uint256 _addTimestamp,
-        uint256 _removeTimestamp
+        uint256 poolTokenRateN,
+        uint256 poolTokenRateD,
+        uint256 poolAmount,
+        uint256 reserveAmount,
+        uint128 addSpotRateN,
+        uint128 addSpotRateD,
+        uint128 removeSpotRateN,
+        uint128 removeSpotRateD,
+        uint128 removeAverageRateN,
+        uint128 removeAverageRateD,
+        uint256 addTimestamp,
+        uint256 removeTimestamp
     ) external returns (uint256) {
-        poolTokenRateOverride = true;
-        poolTokenRateN = _poolTokenRateN;
-        poolTokenRateD = _poolTokenRateD;
+        _poolTokenRateOverride = true;
+        _poolTokenRateN = poolTokenRateN;
+        _poolTokenRateD = poolTokenRateD;
 
         PackedRates memory packedRates =
             PackedRates({
-                addSpotRateN: _addSpotRateN,
-                addSpotRateD: _addSpotRateD,
-                removeSpotRateN: _removeSpotRateN,
-                removeSpotRateD: _removeSpotRateD,
-                removeAverageRateN: _removeAverageRateN,
-                removeAverageRateD: _removeAverageRateD
+                addSpotRateN: addSpotRateN,
+                addSpotRateD: addSpotRateD,
+                removeSpotRateN: removeSpotRateN,
+                removeSpotRateD: removeSpotRateD,
+                removeAverageRateN: removeAverageRateN,
+                removeAverageRateD: removeAverageRateD
             });
 
         uint256 targetAmount =
             removeLiquidityTargetAmount(
                 IDSToken(0),
                 IERC20(0),
-                _poolAmount,
-                _reserveAmount,
+                poolAmount,
+                reserveAmount,
                 packedRates,
-                _addTimestamp,
-                _removeTimestamp
+                addTimestamp,
+                removeTimestamp
             );
-        poolTokenRateOverride = false;
+        _poolTokenRateOverride = false;
         return targetAmount;
     }
 
-    function poolTokenRate(IDSToken _poolToken, IERC20 _reserveToken) internal view override returns (Fraction memory) {
-        if (poolTokenRateOverride) {
-            return Fraction({ n: poolTokenRateN, d: poolTokenRateD });
+    function poolTokenRate(IDSToken poolToken, IERC20 reserveToken) internal view override returns (Fraction memory) {
+        if (_poolTokenRateOverride) {
+            return Fraction({ n: _poolTokenRateN, d: _poolTokenRateD });
         }
-        return super.poolTokenRate(_poolToken, _reserveToken);
+        return super.poolTokenRate(poolToken, reserveToken);
     }
 
     function time() internal view override(Time, TestTime) returns (uint256) {

--- a/solidity/contracts/liquidity-protection/LiquidityProtection.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtection.sol
@@ -375,7 +375,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         IDSToken poolToken = IDSToken(address(poolAnchor));
 
         // get the reserve balances
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(poolAnchor.owner()));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolAnchor)));
         (uint256 reserveBalanceBase, uint256 reserveBalanceNetwork) =
             converterReserveBalances(converter, baseToken, _networkToken);
 
@@ -474,7 +474,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      */
     function _baseTokenAvailableSpace(IConverterAnchor poolAnchor) internal view returns (uint256) {
         // get the pool converter
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(poolAnchor.owner()));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolAnchor)));
 
         // get the base token
         IERC20 baseToken = converterOtherReserve(converter, _networkToken);
@@ -928,7 +928,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
             );
         }
 
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(poolToken.owner()));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolToken)));
         IERC20 otherReserve = converterOtherReserve(converter, reserveToken);
         (uint256 rateN, uint256 rateD) = converterReserveBalances(converter, otherReserve, reserveToken);
 
@@ -969,7 +969,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         uint256 poolTokenSupply = poolToken.totalSupply();
 
         // get the reserve balance
-        IConverter converter = IConverter(payable(poolToken.owner()));
+        IConverter converter = IConverter(payable(ownedBy(poolToken)));
         uint256 reserveBalance = converter.getConnectorBalance(reserveToken);
 
         // for standard pools, 50% of the pool supply value equals the value of each reserve
@@ -997,7 +997,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
             uint256
         )
     {
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(poolToken.owner()));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolToken)));
         IERC20 otherReserve = converterOtherReserve(converter, reserveToken);
 
         (uint256 spotRateN, uint256 spotRateD) = converterReserveBalances(converter, otherReserve, reserveToken);
@@ -1121,7 +1121,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         IERC20 reserveToken1,
         IERC20 reserveToken2
     ) internal {
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(poolToken.owner()));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolToken)));
 
         IERC20[] memory reserveTokens = new IERC20[](2);
         uint256[] memory minReturns = new uint256[](2);
@@ -1371,5 +1371,10 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     function converterOtherReserve(IConverter converter, IERC20 thisReserve) private view returns (IERC20) {
         IERC20 otherReserve = converter.connectorTokens(0);
         return otherReserve != thisReserve ? otherReserve : converter.connectorTokens(1);
+    }
+
+    // utility to get the owner
+    function ownedBy(IOwned owned) private view returns (address) {
+        return owned.owner();
     }
 }

--- a/solidity/contracts/liquidity-protection/LiquidityProtection.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtection.sol
@@ -430,7 +430,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         poolSupportedAndWhitelisted(poolAnchor)
         returns (uint256, uint256)
     {
-        return (_baseTokenAvailableSpace(poolAnchor), _networkTokenAvailableSpace(poolAnchor));
+        return (baseTokenAvailableSpace(poolAnchor), networkTokenAvailableSpace(poolAnchor));
     }
 
     /**
@@ -440,39 +440,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      *
      * @return maximum amount of base tokens that can be single-side staked in the pool
      */
-    function baseTokenAvailableSpace(IConverterAnchor poolAnchor)
-        external
-        view
-        poolSupportedAndWhitelisted(poolAnchor)
-        returns (uint256)
-    {
-        return _baseTokenAvailableSpace(poolAnchor);
-    }
-
-    /**
-     * @dev returns the network-token staking limits of a given pool
-     *
-     * @param poolAnchor anchor of the pool
-     *
-     * @return maximum amount of network tokens that can be single-side staked in the pool
-     */
-    function networkTokenAvailableSpace(IConverterAnchor poolAnchor)
-        external
-        view
-        poolSupportedAndWhitelisted(poolAnchor)
-        returns (uint256)
-    {
-        return _networkTokenAvailableSpace(poolAnchor);
-    }
-
-    /**
-     * @dev returns the base-token staking limits of a given pool
-     *
-     * @param poolAnchor anchor of the pool
-     *
-     * @return maximum amount of base tokens that can be single-side staked in the pool
-     */
-    function _baseTokenAvailableSpace(IConverterAnchor poolAnchor) internal view returns (uint256) {
+    function baseTokenAvailableSpace(IConverterAnchor poolAnchor) internal view returns (uint256) {
         // get the pool converter
         ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolAnchor)));
 
@@ -506,7 +474,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      *
      * @return maximum amount of network tokens that can be single-side staked in the pool
      */
-    function _networkTokenAvailableSpace(IConverterAnchor poolAnchor) internal view returns (uint256) {
+    function networkTokenAvailableSpace(IConverterAnchor poolAnchor) internal view returns (uint256) {
         // get the pool token
         IDSToken poolToken = IDSToken(address(poolAnchor));
 

--- a/solidity/contracts/liquidity-protection/LiquidityProtection.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtection.sol
@@ -375,7 +375,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         IDSToken poolToken = IDSToken(address(poolAnchor));
 
         // get the reserve balances
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolAnchor)));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(poolAnchor.owner()));
         (uint256 reserveBalanceBase, uint256 reserveBalanceNetwork) =
             converterReserveBalances(converter, baseToken, _networkToken);
 
@@ -474,7 +474,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      */
     function _baseTokenAvailableSpace(IConverterAnchor poolAnchor) internal view returns (uint256) {
         // get the pool converter
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolAnchor)));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(poolAnchor.owner()));
 
         // get the base token
         IERC20 baseToken = converterOtherReserve(converter, _networkToken);
@@ -928,7 +928,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
             );
         }
 
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolToken)));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(poolToken.owner()));
         IERC20 otherReserve = converterOtherReserve(converter, reserveToken);
         (uint256 rateN, uint256 rateD) = converterReserveBalances(converter, otherReserve, reserveToken);
 
@@ -969,7 +969,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         uint256 poolTokenSupply = poolToken.totalSupply();
 
         // get the reserve balance
-        IConverter converter = IConverter(payable(ownedBy(poolToken)));
+        IConverter converter = IConverter(payable(poolToken.owner()));
         uint256 reserveBalance = converter.getConnectorBalance(reserveToken);
 
         // for standard pools, 50% of the pool supply value equals the value of each reserve
@@ -997,7 +997,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
             uint256
         )
     {
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolToken)));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(poolToken.owner()));
         IERC20 otherReserve = converterOtherReserve(converter, reserveToken);
 
         (uint256 spotRateN, uint256 spotRateD) = converterReserveBalances(converter, otherReserve, reserveToken);
@@ -1121,7 +1121,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         IERC20 reserveToken1,
         IERC20 reserveToken2
     ) internal {
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolToken)));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(poolToken.owner()));
 
         IERC20[] memory reserveTokens = new IERC20[](2);
         uint256[] memory minReturns = new uint256[](2);
@@ -1371,10 +1371,5 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     function converterOtherReserve(IConverter converter, IERC20 thisReserve) private view returns (IERC20) {
         IERC20 otherReserve = converter.connectorTokens(0);
         return otherReserve != thisReserve ? otherReserve : converter.connectorTokens(1);
-    }
-
-    // utility to get the owner
-    function ownedBy(IOwned owned) private view returns (address) {
-        return owned.owner();
     }
 }

--- a/solidity/contracts/liquidity-protection/LiquidityProtection.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtection.sol
@@ -80,9 +80,6 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     ITokenGovernance private immutable _govTokenGovernance;
     ICheckpointStore private immutable _lastRemoveCheckpointStore;
 
-    // true if the contract is currently adding/removing liquidity from a converter, used for accepting ETH
-    bool private updatingLiquidity = false;
-
     /**
      * @dev initializes a new LiquidityProtection contract
      *
@@ -112,12 +109,6 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
 
         _networkToken = ITokenGovernance(_contractAddresses[5]).token();
         _govToken = ITokenGovernance(_contractAddresses[6]).token();
-    }
-
-    // ensures that the contract is currently removing liquidity from a converter
-    modifier updatingLiquidityOnly() {
-        require(updatingLiquidity, "ERR_NOT_UPDATING_LIQUIDITY");
-        _;
     }
 
     // ensures that the pool is supported and whitelisted
@@ -202,9 +193,8 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
 
     /**
      * @dev accept ETH
-     * used when removing liquidity from ETH converters
      */
-    receive() external payable updatingLiquidityOnly() {}
+    receive() external payable {}
 
     /**
      * @dev transfers the ownership of the store
@@ -1108,9 +1098,6 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         uint256 reserveAmount2,
         uint256 value
     ) internal {
-        // ensure that the contract can receive ETH
-        updatingLiquidity = true;
-
         IERC20[] memory reserveTokens = new IERC20[](2);
         uint256[] memory amounts = new uint256[](2);
         reserveTokens[0] = reserveToken1;
@@ -1118,9 +1105,6 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         amounts[0] = reserveAmount1;
         amounts[1] = reserveAmount2;
         converter.addLiquidity{ value: value }(reserveTokens, amounts, 1);
-
-        // ensure that the contract can receive ETH
-        updatingLiquidity = false;
     }
 
     /**
@@ -1139,9 +1123,6 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     ) internal {
         ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolToken)));
 
-        // ensure that the contract can receive ETH
-        updatingLiquidity = true;
-
         IERC20[] memory reserveTokens = new IERC20[](2);
         uint256[] memory minReturns = new uint256[](2);
         reserveTokens[0] = reserveToken1;
@@ -1149,9 +1130,6 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         minReturns[0] = 1;
         minReturns[1] = 1;
         converter.removeLiquidity(poolAmount, reserveTokens, minReturns);
-
-        // ensure that the contract can receive ETH
-        updatingLiquidity = false;
     }
 
     /**

--- a/solidity/contracts/liquidity-protection/LiquidityProtection.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtection.sol
@@ -14,11 +14,13 @@ import "../utility/Types.sol";
 import "../utility/Time.sol";
 import "../utility/Utils.sol";
 import "../utility/Owned.sol";
-import "./interfaces/ILiquidityProtection.sol";
+
 import "../token/interfaces/IDSToken.sol";
 import "../converter/interfaces/IConverterAnchor.sol";
 import "../converter/interfaces/IConverter.sol";
 import "../converter/interfaces/IConverterRegistry.sol";
+
+import "./interfaces/ILiquidityProtection.sol";
 
 interface ILiquidityPoolConverter is IConverter {
     function addLiquidity(

--- a/solidity/contracts/liquidity-protection/LiquidityProtection.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtection.sol
@@ -22,18 +22,18 @@ import "../converter/interfaces/IConverterRegistry.sol";
 
 interface ILiquidityPoolConverter is IConverter {
     function addLiquidity(
-        IERC20[] memory _reserveTokens,
-        uint256[] memory _reserveAmounts,
+        IERC20[] memory reserveTokens,
+        uint256[] memory reserveAmounts,
         uint256 _minReturn
     ) external payable;
 
     function removeLiquidity(
-        uint256 _amount,
-        IERC20[] memory _reserveTokens,
+        uint256 amount,
+        IERC20[] memory reserveTokens,
         uint256[] memory _reserveMinReturnAmounts
     ) external;
 
-    function recentAverageRate(IERC20 _reserveToken) external view returns (uint256, uint256);
+    function recentAverageRate(IERC20 reserveToken) external view returns (uint256, uint256);
 }
 
 /**
@@ -69,16 +69,16 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     uint256 internal constant MAX_UINT128 = 2**128 - 1;
     uint256 internal constant MAX_UINT256 = uint256(-1);
 
-    ILiquidityProtectionSettings public immutable override settings;
-    ILiquidityProtectionStore public immutable override store;
-    ILiquidityProtectionStats public immutable override stats;
-    ILiquidityProtectionSystemStore public immutable override systemStore;
-    ITokenHolder public immutable override wallet;
-    IERC20 public immutable networkToken;
-    ITokenGovernance public immutable networkTokenGovernance;
-    IERC20 public immutable govToken;
-    ITokenGovernance public immutable govTokenGovernance;
-    ICheckpointStore public immutable lastRemoveCheckpointStore;
+    ILiquidityProtectionSettings private immutable _settings;
+    ILiquidityProtectionStore private immutable _store;
+    ILiquidityProtectionStats private immutable _stats;
+    ILiquidityProtectionSystemStore private immutable _systemStore;
+    ITokenHolder private immutable _wallet;
+    IERC20 private immutable _networkToken;
+    ITokenGovernance private immutable _networkTokenGovernance;
+    IERC20 private immutable _govToken;
+    ITokenGovernance private immutable _govTokenGovernance;
+    ICheckpointStore private immutable _lastRemoveCheckpointStore;
 
     // true if the contract is currently adding/removing liquidity from a converter, used for accepting ETH
     bool private updatingLiquidity = false;
@@ -101,17 +101,17 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
             _validAddress(_contractAddresses[i]);
         }
 
-        settings = ILiquidityProtectionSettings(_contractAddresses[0]);
-        store = ILiquidityProtectionStore(_contractAddresses[1]);
-        stats = ILiquidityProtectionStats(_contractAddresses[2]);
-        systemStore = ILiquidityProtectionSystemStore(_contractAddresses[3]);
-        wallet = ITokenHolder(payable(_contractAddresses[4]));
-        networkTokenGovernance = ITokenGovernance(_contractAddresses[5]);
-        govTokenGovernance = ITokenGovernance(_contractAddresses[6]);
-        lastRemoveCheckpointStore = ICheckpointStore(_contractAddresses[7]);
+        _settings = ILiquidityProtectionSettings(_contractAddresses[0]);
+        _store = ILiquidityProtectionStore(_contractAddresses[1]);
+        _stats = ILiquidityProtectionStats(_contractAddresses[2]);
+        _systemStore = ILiquidityProtectionSystemStore(_contractAddresses[3]);
+        _wallet = ITokenHolder(payable(_contractAddresses[4]));
+        _networkTokenGovernance = ITokenGovernance(_contractAddresses[5]);
+        _govTokenGovernance = ITokenGovernance(_contractAddresses[6]);
+        _lastRemoveCheckpointStore = ICheckpointStore(_contractAddresses[7]);
 
-        networkToken = IERC20(address(ITokenGovernance(_contractAddresses[5]).token()));
-        govToken = IERC20(address(ITokenGovernance(_contractAddresses[6]).token()));
+        _networkToken = ITokenGovernance(_contractAddresses[5]).token();
+        _govToken = ITokenGovernance(_contractAddresses[6]).token();
     }
 
     // ensures that the contract is currently removing liquidity from a converter
@@ -121,36 +121,83 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     }
 
     // ensures that the pool is supported and whitelisted
-    modifier poolSupportedAndWhitelisted(IConverterAnchor _poolAnchor) {
-        _poolSupported(_poolAnchor);
-        _poolWhitelisted(_poolAnchor);
+    modifier poolSupportedAndWhitelisted(IConverterAnchor poolAnchor) {
+        _poolSupported(poolAnchor);
+        _poolWhitelisted(poolAnchor);
+
         _;
     }
 
     // ensures that add liquidity is enabled
-    modifier addLiquidityEnabled(IConverterAnchor _poolAnchor, IERC20 _reserveToken) {
-        _addLiquidityEnabled(_poolAnchor, _reserveToken);
+    modifier addLiquidityEnabled(IConverterAnchor poolAnchor, IERC20 reserveToken) {
+        _addLiquidityEnabled(poolAnchor, reserveToken);
+
         _;
     }
 
     // error message binary size optimization
-    function _poolSupported(IConverterAnchor _poolAnchor) internal view {
-        require(settings.isPoolSupported(_poolAnchor), "ERR_POOL_NOT_SUPPORTED");
+    function _poolSupported(IConverterAnchor poolAnchor) internal view {
+        require(_settings.isPoolSupported(poolAnchor), "ERR_POOL_NOT_SUPPORTED");
     }
 
     // error message binary size optimization
-    function _poolWhitelisted(IConverterAnchor _poolAnchor) internal view {
-        require(settings.isPoolWhitelisted(_poolAnchor), "ERR_POOL_NOT_WHITELISTED");
+    function _poolWhitelisted(IConverterAnchor poolAnchor) internal view {
+        require(_settings.isPoolWhitelisted(poolAnchor), "ERR_POOL_NOT_WHITELISTED");
     }
 
     // error message binary size optimization
-    function _addLiquidityEnabled(IConverterAnchor _poolAnchor, IERC20 _reserveToken) internal view {
-        require(!settings.addLiquidityDisabled(_poolAnchor, _reserveToken), "ERR_ADD_LIQUIDITY_DISABLED");
+    function _addLiquidityEnabled(IConverterAnchor poolAnchor, IERC20 reserveToken) internal view {
+        require(!_settings.addLiquidityDisabled(poolAnchor, reserveToken), "ERR_ADD_LIQUIDITY_DISABLED");
     }
 
     // error message binary size optimization
-    function verifyEthAmount(uint256 _value) internal view {
-        require(msg.value == _value, "ERR_ETH_AMOUNT_MISMATCH");
+    function verifyEthAmount(uint256 value) internal view {
+        require(msg.value == value, "ERR_ETH_AMOUNT_MISMATCH");
+    }
+
+    /**
+     * @dev returns the LP store
+     *
+     * @return the LP store
+     */
+    function store() external view override returns (ILiquidityProtectionStore) {
+        return _store;
+    }
+
+    /**
+     * @dev returns the LP stats
+     *
+     * @return the LP stats
+     */
+    function stats() external view override returns (ILiquidityProtectionStats) {
+        return _stats;
+    }
+
+    /**
+     * @dev returns the LP settings
+     *
+     * @return the LP settings
+     */
+    function settings() external view override returns (ILiquidityProtectionSettings) {
+        return _settings;
+    }
+
+    /**
+     * @dev returns the LP system store
+     *
+     * @return the LP settings
+     */
+    function systemStore() external view override returns (ILiquidityProtectionSystemStore) {
+        return _systemStore;
+    }
+
+    /**
+     * @dev returns the LP wallet
+     *
+     * @return the LP wallet
+     */
+    function wallet() external view override returns (ITokenHolder) {
+        return _wallet;
     }
 
     /**
@@ -163,10 +210,10 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      * @dev transfers the ownership of the store
      * can only be called by the contract owner
      *
-     * @param _newOwner    the new owner of the store
+     * @param newOwner the new owner of the store
      */
-    function transferStoreOwnership(address _newOwner) external ownerOnly {
-        store.transferOwnership(_newOwner);
+    function transferStoreOwnership(address newOwner) external ownerOnly {
+        _store.transferOwnership(newOwner);
     }
 
     /**
@@ -174,17 +221,17 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      * can only be called by the contract owner
      */
     function acceptStoreOwnership() external ownerOnly {
-        store.acceptOwnership();
+        _store.acceptOwnership();
     }
 
     /**
      * @dev transfers the ownership of the wallet
      * can only be called by the contract owner
      *
-     * @param _newOwner    the new owner of the wallet
+     * @param newOwner the new owner of the wallet
      */
-    function transferWalletOwnership(address _newOwner) external ownerOnly {
-        wallet.transferOwnership(_newOwner);
+    function transferWalletOwnership(address newOwner) external ownerOnly {
+        _wallet.transferOwnership(newOwner);
     }
 
     /**
@@ -192,130 +239,129 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      * can only be called by the contract owner
      */
     function acceptWalletOwnership() external ownerOnly {
-        wallet.acceptOwnership();
+        _wallet.acceptOwnership();
     }
 
     /**
      * @dev adds protected liquidity to a pool for a specific recipient
      * also mints new governance tokens for the caller if the caller adds network tokens
      *
-     * @param _owner       protected liquidity owner
-     * @param _poolAnchor      anchor of the pool
-     * @param _reserveToken    reserve token to add to the pool
-     * @param _amount          amount of tokens to add to the pool
+     * @param owner protected liquidity owner
+     * @param poolAnchor anchor of the pool
+     * @param reserveToken reserve token to add to the pool
+     * @param amount amount of tokens to add to the pool
+     *
      * @return new protected liquidity id
      */
     function addLiquidityFor(
-        address _owner,
-        IConverterAnchor _poolAnchor,
-        IERC20 _reserveToken,
-        uint256 _amount
+        address owner,
+        IConverterAnchor poolAnchor,
+        IERC20 reserveToken,
+        uint256 amount
     )
         external
         payable
         override
         protected
-        validAddress(_owner)
-        poolSupportedAndWhitelisted(_poolAnchor)
-        addLiquidityEnabled(_poolAnchor, _reserveToken)
-        greaterThanZero(_amount)
+        validAddress(owner)
+        poolSupportedAndWhitelisted(poolAnchor)
+        addLiquidityEnabled(poolAnchor, reserveToken)
+        greaterThanZero(amount)
         returns (uint256)
     {
-        return addLiquidity(_owner, _poolAnchor, _reserveToken, _amount);
+        return addLiquidity(owner, poolAnchor, reserveToken, amount);
     }
 
     /**
      * @dev adds protected liquidity to a pool
      * also mints new governance tokens for the caller if the caller adds network tokens
      *
-     * @param _poolAnchor      anchor of the pool
-     * @param _reserveToken    reserve token to add to the pool
-     * @param _amount          amount of tokens to add to the pool
+     * @param poolAnchor anchor of the pool
+     * @param reserveToken reserve token to add to the pool
+     * @param amount amount of tokens to add to the pool
+     *
      * @return new protected liquidity id
      */
     function addLiquidity(
-        IConverterAnchor _poolAnchor,
-        IERC20 _reserveToken,
-        uint256 _amount
+        IConverterAnchor poolAnchor,
+        IERC20 reserveToken,
+        uint256 amount
     )
         external
         payable
         override
         protected
-        poolSupportedAndWhitelisted(_poolAnchor)
-        addLiquidityEnabled(_poolAnchor, _reserveToken)
-        greaterThanZero(_amount)
+        poolSupportedAndWhitelisted(poolAnchor)
+        addLiquidityEnabled(poolAnchor, reserveToken)
+        greaterThanZero(amount)
         returns (uint256)
     {
-        return addLiquidity(msg.sender, _poolAnchor, _reserveToken, _amount);
+        return addLiquidity(msg.sender, poolAnchor, reserveToken, amount);
     }
 
     /**
      * @dev adds protected liquidity to a pool for a specific recipient
      * also mints new governance tokens for the caller if the caller adds network tokens
      *
-     * @param _owner       protected liquidity owner
-     * @param _poolAnchor      anchor of the pool
-     * @param _reserveToken    reserve token to add to the pool
-     * @param _amount          amount of tokens to add to the pool
+     * @param owner protected liquidity owner
+     * @param poolAnchor anchor of the pool
+     * @param reserveToken reserve token to add to the pool
+     * @param amount amount of tokens to add to the pool
+     *
      * @return new protected liquidity id
      */
     function addLiquidity(
-        address _owner,
-        IConverterAnchor _poolAnchor,
-        IERC20 _reserveToken,
-        uint256 _amount
+        address owner,
+        IConverterAnchor poolAnchor,
+        IERC20 reserveToken,
+        uint256 amount
     ) private returns (uint256) {
-        // save a local copy of `networkToken`
-        IERC20 networkTokenLocal = networkToken;
-
-        if (_reserveToken == networkTokenLocal) {
+        if (reserveToken == _networkToken) {
             verifyEthAmount(0);
-            return addNetworkTokenLiquidity(_owner, _poolAnchor, networkTokenLocal, _amount);
+            return addNetworkTokenLiquidity(owner, poolAnchor, amount);
         }
 
         // verify that ETH was passed with the call if needed
-        verifyEthAmount(_reserveToken == NATIVE_TOKEN_ADDRESS ? _amount : 0);
-        return addBaseTokenLiquidity(_owner, _poolAnchor, _reserveToken, networkTokenLocal, _amount);
+        verifyEthAmount(reserveToken == NATIVE_TOKEN_ADDRESS ? amount : 0);
+        return addBaseTokenLiquidity(owner, poolAnchor, reserveToken, amount);
     }
 
     /**
      * @dev adds protected network token liquidity to a pool
      * also mints new governance tokens for the caller
      *
-     * @param _owner    protected liquidity owner
-     * @param _poolAnchor   anchor of the pool
-     * @param _networkToken the network reserve token of the pool
-     * @param _amount       amount of tokens to add to the pool
+     * @param owner protected liquidity owner
+     * @param poolAnchor anchor of the pool
+     * @param amount amount of tokens to add to the pool
+     *
      * @return new protected liquidity id
      */
     function addNetworkTokenLiquidity(
-        address _owner,
-        IConverterAnchor _poolAnchor,
-        IERC20 _networkToken,
-        uint256 _amount
+        address owner,
+        IConverterAnchor poolAnchor,
+        uint256 amount
     ) internal returns (uint256) {
-        IDSToken poolToken = IDSToken(address(_poolAnchor));
+        IDSToken poolToken = IDSToken(address(poolAnchor));
 
         // get the rate between the pool token and the reserve
         Fraction memory poolRate = poolTokenRate(poolToken, _networkToken);
 
         // calculate the amount of pool tokens based on the amount of reserve tokens
-        uint256 poolTokenAmount = _amount.mul(poolRate.d).div(poolRate.n);
+        uint256 poolTokenAmount = amount.mul(poolRate.d).div(poolRate.n);
 
         // remove the pool tokens from the system's ownership (will revert if not enough tokens are available)
-        systemStore.decSystemBalance(poolToken, poolTokenAmount);
+        _systemStore.decSystemBalance(poolToken, poolTokenAmount);
 
         // add protected liquidity for the recipient
-        uint256 id = addProtectedLiquidity(_owner, poolToken, _networkToken, poolTokenAmount, _amount);
+        uint256 id = addProtectedLiquidity(owner, poolToken, _networkToken, poolTokenAmount, amount);
 
         // burns the network tokens from the caller. we need to transfer the tokens to the contract itself, since only
         // token holders can burn their tokens
-        _networkToken.safeTransferFrom(msg.sender, address(this), _amount);
-        burnNetworkTokens(_poolAnchor, _amount);
+        _networkToken.safeTransferFrom(msg.sender, address(this), amount);
+        burnNetworkTokens(poolAnchor, amount);
 
         // mint governance tokens to the recipient
-        govTokenGovernance.mint(_owner, _amount);
+        _govTokenGovernance.mint(owner, amount);
 
         return id;
     }
@@ -323,128 +369,122 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     /**
      * @dev adds protected base token liquidity to a pool
      *
-     * @param _owner    protected liquidity owner
-     * @param _poolAnchor   anchor of the pool
-     * @param _baseToken    the base reserve token of the pool
-     * @param _networkToken the network reserve token of the pool
-     * @param _amount       amount of tokens to add to the pool
+     * @param owner protected liquidity owner
+     * @param poolAnchor anchor of the pool
+     * @param baseToken the base reserve token of the pool
+     * @param amount amount of tokens to add to the pool
+     *
      * @return new protected liquidity id
      */
     function addBaseTokenLiquidity(
-        address _owner,
-        IConverterAnchor _poolAnchor,
-        IERC20 _baseToken,
-        IERC20 _networkToken,
-        uint256 _amount
+        address owner,
+        IConverterAnchor poolAnchor,
+        IERC20 baseToken,
+        uint256 amount
     ) internal returns (uint256) {
-        IDSToken poolToken = IDSToken(address(_poolAnchor));
+        IDSToken poolToken = IDSToken(address(poolAnchor));
 
         // get the reserve balances
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(_poolAnchor)));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolAnchor)));
         (uint256 reserveBalanceBase, uint256 reserveBalanceNetwork) =
-            converterReserveBalances(converter, _baseToken, _networkToken);
+            converterReserveBalances(converter, baseToken, _networkToken);
 
-        require(reserveBalanceNetwork >= settings.minNetworkTokenLiquidityForMinting(), "ERR_NOT_ENOUGH_LIQUIDITY");
+        require(reserveBalanceNetwork >= _settings.minNetworkTokenLiquidityForMinting(), "ERR_NOT_ENOUGH_LIQUIDITY");
 
         // calculate and mint the required amount of network tokens for adding liquidity
-        uint256 newNetworkLiquidityAmount = _amount.mul(reserveBalanceNetwork).div(reserveBalanceBase);
+        uint256 newNetworkLiquidityAmount = amount.mul(reserveBalanceNetwork).div(reserveBalanceBase);
 
         // verify network token minting limit
-        uint256 mintingLimit = settings.networkTokenMintingLimits(_poolAnchor);
+        uint256 mintingLimit = _settings.networkTokenMintingLimits(poolAnchor);
         if (mintingLimit == 0) {
-            mintingLimit = settings.defaultNetworkTokenMintingLimit();
+            mintingLimit = _settings.defaultNetworkTokenMintingLimit();
         }
 
-        uint256 newNetworkTokensMinted = systemStore.networkTokensMinted(_poolAnchor).add(newNetworkLiquidityAmount);
+        uint256 newNetworkTokensMinted = _systemStore.networkTokensMinted(poolAnchor).add(newNetworkLiquidityAmount);
         require(newNetworkTokensMinted <= mintingLimit, "ERR_MAX_AMOUNT_REACHED");
 
         // issue new network tokens to the system
-        mintNetworkTokens(address(this), _poolAnchor, newNetworkLiquidityAmount);
+        mintNetworkTokens(address(this), poolAnchor, newNetworkLiquidityAmount);
 
         // transfer the base tokens from the caller and approve the converter
         ensureAllowance(_networkToken, address(converter), newNetworkLiquidityAmount);
-        if (_baseToken != NATIVE_TOKEN_ADDRESS) {
-            _baseToken.safeTransferFrom(msg.sender, address(this), _amount);
-            ensureAllowance(_baseToken, address(converter), _amount);
+        if (baseToken != NATIVE_TOKEN_ADDRESS) {
+            baseToken.safeTransferFrom(msg.sender, address(this), amount);
+            ensureAllowance(baseToken, address(converter), amount);
         }
 
         // add liquidity
-        addLiquidity(converter, _baseToken, _networkToken, _amount, newNetworkLiquidityAmount, msg.value);
+        addLiquidity(converter, baseToken, _networkToken, amount, newNetworkLiquidityAmount, msg.value);
 
         // transfer the new pool tokens to the wallet
         uint256 poolTokenAmount = poolToken.balanceOf(address(this));
-        poolToken.safeTransfer(address(wallet), poolTokenAmount);
+        poolToken.safeTransfer(address(_wallet), poolTokenAmount);
 
         // the system splits the pool tokens with the caller
         // increase the system's pool token balance and add protected liquidity for the caller
-        systemStore.incSystemBalance(poolToken, poolTokenAmount - poolTokenAmount / 2); // account for rounding errors
-        return addProtectedLiquidity(_owner, poolToken, _baseToken, poolTokenAmount / 2, _amount);
+        _systemStore.incSystemBalance(poolToken, poolTokenAmount - poolTokenAmount / 2); // account for rounding errors
+        return addProtectedLiquidity(owner, poolToken, baseToken, poolTokenAmount / 2, amount);
     }
 
     /**
      * @dev returns the single-side staking limits of a given pool
      *
-     * @param _poolAnchor   anchor of the pool
+     * @param poolAnchor anchor of the pool
+     *
      * @return maximum amount of base tokens that can be single-side staked in the pool
      * @return maximum amount of network tokens that can be single-side staked in the pool
      */
-    function poolAvailableSpace(IConverterAnchor _poolAnchor)
+    function poolAvailableSpace(IConverterAnchor poolAnchor)
         external
         view
-        poolSupportedAndWhitelisted(_poolAnchor)
+        poolSupportedAndWhitelisted(poolAnchor)
         returns (uint256, uint256)
     {
-        IERC20 networkTokenLocal = networkToken;
-        return (
-            baseTokenAvailableSpace(_poolAnchor, networkTokenLocal),
-            networkTokenAvailableSpace(_poolAnchor, networkTokenLocal)
-        );
+        return (_baseTokenAvailableSpace(poolAnchor), _networkTokenAvailableSpace(poolAnchor));
     }
 
     /**
      * @dev returns the base-token staking limits of a given pool
      *
-     * @param _poolAnchor   anchor of the pool
+     * @param poolAnchor anchor of the pool
+     *
      * @return maximum amount of base tokens that can be single-side staked in the pool
      */
-    function baseTokenAvailableSpace(IConverterAnchor _poolAnchor)
+    function baseTokenAvailableSpace(IConverterAnchor poolAnchor)
         external
         view
-        poolSupportedAndWhitelisted(_poolAnchor)
+        poolSupportedAndWhitelisted(poolAnchor)
         returns (uint256)
     {
-        return baseTokenAvailableSpace(_poolAnchor, networkToken);
+        return _baseTokenAvailableSpace(poolAnchor);
     }
 
     /**
      * @dev returns the network-token staking limits of a given pool
      *
-     * @param _poolAnchor   anchor of the pool
+     * @param poolAnchor anchor of the pool
+     *
      * @return maximum amount of network tokens that can be single-side staked in the pool
      */
-    function networkTokenAvailableSpace(IConverterAnchor _poolAnchor)
+    function networkTokenAvailableSpace(IConverterAnchor poolAnchor)
         external
         view
-        poolSupportedAndWhitelisted(_poolAnchor)
+        poolSupportedAndWhitelisted(poolAnchor)
         returns (uint256)
     {
-        return networkTokenAvailableSpace(_poolAnchor, networkToken);
+        return _networkTokenAvailableSpace(poolAnchor);
     }
 
     /**
      * @dev returns the base-token staking limits of a given pool
      *
-     * @param _poolAnchor   anchor of the pool
-     * @param _networkToken the network token
+     * @param poolAnchor anchor of the pool
+     *
      * @return maximum amount of base tokens that can be single-side staked in the pool
      */
-    function baseTokenAvailableSpace(IConverterAnchor _poolAnchor, IERC20 _networkToken)
-        internal
-        view
-        returns (uint256)
-    {
+    function _baseTokenAvailableSpace(IConverterAnchor poolAnchor) internal view returns (uint256) {
         // get the pool converter
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(_poolAnchor)));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolAnchor)));
 
         // get the base token
         IERC20 baseToken = converterOtherReserve(converter, _networkToken);
@@ -454,13 +494,13 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
             converterReserveBalances(converter, baseToken, _networkToken);
 
         // get the network token minting limit
-        uint256 mintingLimit = settings.networkTokenMintingLimits(_poolAnchor);
+        uint256 mintingLimit = _settings.networkTokenMintingLimits(poolAnchor);
         if (mintingLimit == 0) {
-            mintingLimit = settings.defaultNetworkTokenMintingLimit();
+            mintingLimit = _settings.defaultNetworkTokenMintingLimit();
         }
 
         // get the amount of network tokens already minted for the pool
-        uint256 networkTokensMinted = systemStore.networkTokensMinted(_poolAnchor);
+        uint256 networkTokensMinted = _systemStore.networkTokensMinted(poolAnchor);
 
         // get the amount of network tokens which can minted for the pool
         uint256 networkTokensCanBeMinted = MathEx.max(mintingLimit, networkTokensMinted) - networkTokensMinted;
@@ -472,23 +512,19 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     /**
      * @dev returns the network-token staking limits of a given pool
      *
-     * @param _poolAnchor   anchor of the pool
-     * @param _networkToken the network token
+     * @param poolAnchor anchor of the pool
+     *
      * @return maximum amount of network tokens that can be single-side staked in the pool
      */
-    function networkTokenAvailableSpace(IConverterAnchor _poolAnchor, IERC20 _networkToken)
-        internal
-        view
-        returns (uint256)
-    {
+    function _networkTokenAvailableSpace(IConverterAnchor poolAnchor) internal view returns (uint256) {
         // get the pool token
-        IDSToken poolToken = IDSToken(address(_poolAnchor));
+        IDSToken poolToken = IDSToken(address(poolAnchor));
 
         // get the pool token rate
         Fraction memory poolRate = poolTokenRate(poolToken, _networkToken);
 
         // return the maximum amount of network token liquidity that can be single-sided staked in the pool
-        return systemStore.systemBalance(poolToken).mul(poolRate.n).add(poolRate.n).sub(1).div(poolRate.d);
+        return _systemStore.systemBalance(poolToken).mul(poolRate.n).add(poolRate.n).sub(1).div(poolRate.d);
     }
 
     /**
@@ -496,37 +532,38 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      * it's also possible to provide the remove liquidity time to get an estimation
      * for the return at that given point
      *
-     * @param _id              protected liquidity id
-     * @param _portion         portion of liquidity to remove, in PPM
-     * @param _removeTimestamp time at which the liquidity is removed
+     * @param id protected liquidity id
+     * @param portion portion of liquidity to remove, in PPM
+     * @param removeTimestamp time at which the liquidity is removed
+     *
      * @return expected return amount in the reserve token
      * @return actual return amount in the reserve token
      * @return compensation in the network token
      */
     function removeLiquidityReturn(
-        uint256 _id,
-        uint32 _portion,
-        uint256 _removeTimestamp
+        uint256 id,
+        uint32 portion,
+        uint256 removeTimestamp
     )
         external
         view
-        validPortion(_portion)
+        validPortion(portion)
         returns (
             uint256,
             uint256,
             uint256
         )
     {
-        ProtectedLiquidity memory liquidity = protectedLiquidity(_id);
+        ProtectedLiquidity memory liquidity = protectedLiquidity(id);
 
         // verify input
         require(liquidity.provider != address(0), "ERR_INVALID_ID");
-        require(_removeTimestamp >= liquidity.timestamp, "ERR_INVALID_TIMESTAMP");
+        require(removeTimestamp >= liquidity.timestamp, "ERR_INVALID_TIMESTAMP");
 
         // calculate the portion of the liquidity to remove
-        if (_portion != PPM_RESOLUTION) {
-            liquidity.poolAmount = liquidity.poolAmount.mul(_portion) / PPM_RESOLUTION;
-            liquidity.reserveAmount = liquidity.reserveAmount.mul(_portion) / PPM_RESOLUTION;
+        if (portion != PPM_RESOLUTION) {
+            liquidity.poolAmount = liquidity.poolAmount.mul(portion) / PPM_RESOLUTION;
+            liquidity.reserveAmount = liquidity.reserveAmount.mul(portion) / PPM_RESOLUTION;
         }
 
         // get the various rates between the reserves upon adding liquidity and now
@@ -547,11 +584,11 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
                 liquidity.reserveAmount,
                 packedRates,
                 liquidity.timestamp,
-                _removeTimestamp
+                removeTimestamp
             );
 
         // for network token, the return amount is identical to the target amount
-        if (liquidity.reserveToken == networkToken) {
+        if (liquidity.reserveToken == _networkToken) {
             return (targetAmount, targetAmount, 0);
         }
 
@@ -563,13 +600,13 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         uint256 poolAmount = targetAmount.mul(poolRate.d).div(poolRate.n / 2);
 
         // limit the amount of pool tokens by the amount the system/caller holds
-        uint256 availableBalance = systemStore.systemBalance(liquidity.poolToken).add(liquidity.poolAmount);
+        uint256 availableBalance = _systemStore.systemBalance(liquidity.poolToken).add(liquidity.poolAmount);
         poolAmount = poolAmount > availableBalance ? availableBalance : poolAmount;
 
         // calculate the base token amount received by liquidating the pool tokens
         // note that the amount is divided by 2 since the pool amount represents both reserves
         uint256 baseAmount = poolAmount.mul(poolRate.n / 2).div(poolRate.d);
-        uint256 networkAmount = getNetworkCompensation(targetAmount, baseAmount, packedRates);
+        uint256 networkAmount = networkCompensation(targetAmount, baseAmount, packedRates);
 
         return (targetAmount, baseAmount, networkAmount);
     }
@@ -578,30 +615,27 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      * @dev removes protected liquidity from a pool
      * also burns governance tokens from the caller if the caller removes network tokens
      *
-     * @param _id      id in the caller's list of protected liquidity
-     * @param _portion portion of liquidity to remove, in PPM
+     * @param id id in the caller's list of protected liquidity
+     * @param portion portion of liquidity to remove, in PPM
      */
-    function removeLiquidity(uint256 _id, uint32 _portion) external override protected validPortion(_portion) {
-        removeLiquidity(msg.sender, _id, _portion);
+    function removeLiquidity(uint256 id, uint32 portion) external override protected validPortion(portion) {
+        removeLiquidity(msg.sender, id, portion);
     }
 
     /**
      * @dev removes protected liquidity from a pool
      * also burns governance tokens from the caller if the caller removes network tokens
      *
-     * @param _provider protected liquidity provider
-     * @param _id id in the caller's list of protected liquidity
-     * @param _portion portion of liquidity to remove, in PPM
+     * @param provider protected liquidity provider
+     * @param id id in the caller's list of protected liquidity
+     * @param portion portion of liquidity to remove, in PPM
      */
     function removeLiquidity(
-        address payable _provider,
-        uint256 _id,
-        uint32 _portion
+        address payable provider,
+        uint256 id,
+        uint32 portion
     ) internal {
-        ProtectedLiquidity memory liquidity = protectedLiquidity(_id, _provider);
-
-        // save a local copy of `networkToken`
-        IERC20 networkTokenLocal = networkToken;
+        ProtectedLiquidity memory liquidity = protectedLiquidity(id, provider);
 
         // verify that the pool is whitelisted
         _poolWhitelisted(liquidity.poolToken);
@@ -609,11 +643,11 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         // verify that the protected liquidity is not removed on the same block in which it was added
         require(liquidity.timestamp < time(), "ERR_TOO_EARLY");
 
-        if (_portion == PPM_RESOLUTION) {
+        if (portion == PPM_RESOLUTION) {
             // notify event subscribers
             notifyEventSubscribersOnRemovingLiquidity(
-                _id,
-                _provider,
+                id,
+                provider,
                 liquidity.poolToken,
                 liquidity.reserveToken,
                 liquidity.poolAmount,
@@ -621,33 +655,33 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
             );
 
             // remove the protected liquidity from the provider
-            store.removeProtectedLiquidity(_id);
+            _store.removeProtectedLiquidity(id);
         } else {
             // remove a portion of the protected liquidity from the provider
             uint256 fullPoolAmount = liquidity.poolAmount;
             uint256 fullReserveAmount = liquidity.reserveAmount;
-            liquidity.poolAmount = liquidity.poolAmount.mul(_portion) / PPM_RESOLUTION;
-            liquidity.reserveAmount = liquidity.reserveAmount.mul(_portion) / PPM_RESOLUTION;
+            liquidity.poolAmount = liquidity.poolAmount.mul(portion) / PPM_RESOLUTION;
+            liquidity.reserveAmount = liquidity.reserveAmount.mul(portion) / PPM_RESOLUTION;
 
             // notify event subscribers
             notifyEventSubscribersOnRemovingLiquidity(
-                _id,
-                _provider,
+                id,
+                provider,
                 liquidity.poolToken,
                 liquidity.reserveToken,
                 liquidity.poolAmount,
                 liquidity.reserveAmount
             );
 
-            store.updateProtectedLiquidityAmounts(
-                _id,
+            _store.updateProtectedLiquidityAmounts(
+                id,
                 fullPoolAmount - liquidity.poolAmount,
                 fullReserveAmount - liquidity.reserveAmount
             );
         }
 
         // update the statistics
-        stats.decreaseTotalAmounts(
+        _stats.decreaseTotalAmounts(
             liquidity.provider,
             liquidity.poolToken,
             liquidity.reserveToken,
@@ -656,16 +690,16 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         );
 
         // update last liquidity removal checkpoint
-        lastRemoveCheckpointStore.addCheckpoint(_provider);
+        _lastRemoveCheckpointStore.addCheckpoint(provider);
 
         // add the pool tokens to the system
-        systemStore.incSystemBalance(liquidity.poolToken, liquidity.poolAmount);
+        _systemStore.incSystemBalance(liquidity.poolToken, liquidity.poolAmount);
 
         // if removing network token liquidity, burn the governance tokens from the caller. we need to transfer the
         // tokens to the contract itself, since only token holders can burn their tokens
-        if (liquidity.reserveToken == networkTokenLocal) {
-            govToken.safeTransferFrom(_provider, address(this), liquidity.reserveAmount);
-            govTokenGovernance.burn(liquidity.reserveAmount);
+        if (liquidity.reserveToken == _networkToken) {
+            _govToken.safeTransferFrom(provider, address(this), liquidity.reserveAmount);
+            _govTokenGovernance.burn(liquidity.reserveAmount);
         }
 
         // get the various rates between the reserves upon adding liquidity and now
@@ -691,10 +725,10 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
             );
 
         // remove network token liquidity
-        if (liquidity.reserveToken == networkTokenLocal) {
+        if (liquidity.reserveToken == _networkToken) {
             // mint network tokens for the caller and lock them
-            mintNetworkTokens(address(wallet), liquidity.poolToken, targetAmount);
-            lockTokens(_provider, targetAmount);
+            mintNetworkTokens(address(_wallet), liquidity.poolToken, targetAmount);
+            lockTokens(provider, targetAmount);
             return;
         }
 
@@ -706,42 +740,42 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         uint256 poolAmount = targetAmount.mul(poolRate.d).div(poolRate.n / 2);
 
         // limit the amount of pool tokens by the amount the system holds
-        uint256 systemBalance = systemStore.systemBalance(liquidity.poolToken);
+        uint256 systemBalance = _systemStore.systemBalance(liquidity.poolToken);
         poolAmount = poolAmount > systemBalance ? systemBalance : poolAmount;
 
         // withdraw the pool tokens from the wallet
-        systemStore.decSystemBalance(liquidity.poolToken, poolAmount);
-        wallet.withdrawTokens(liquidity.poolToken, address(this), poolAmount);
+        _systemStore.decSystemBalance(liquidity.poolToken, poolAmount);
+        _wallet.withdrawTokens(liquidity.poolToken, address(this), poolAmount);
 
         // remove liquidity
-        removeLiquidity(liquidity.poolToken, poolAmount, liquidity.reserveToken, networkTokenLocal);
+        removeLiquidity(liquidity.poolToken, poolAmount, liquidity.reserveToken, _networkToken);
 
         // transfer the base tokens to the caller
         uint256 baseBalance;
         if (liquidity.reserveToken == NATIVE_TOKEN_ADDRESS) {
             baseBalance = address(this).balance;
-            _provider.transfer(baseBalance);
+            provider.transfer(baseBalance);
         } else {
             baseBalance = liquidity.reserveToken.balanceOf(address(this));
-            liquidity.reserveToken.safeTransfer(_provider, baseBalance);
+            liquidity.reserveToken.safeTransfer(provider, baseBalance);
         }
 
         // compensate the caller with network tokens if still needed
-        uint256 delta = getNetworkCompensation(targetAmount, baseBalance, packedRates);
+        uint256 delta = networkCompensation(targetAmount, baseBalance, packedRates);
         if (delta > 0) {
             // check if there's enough network token balance, otherwise mint more
-            uint256 networkBalance = networkTokenLocal.balanceOf(address(this));
+            uint256 networkBalance = _networkToken.balanceOf(address(this));
             if (networkBalance < delta) {
-                networkTokenGovernance.mint(address(this), delta - networkBalance);
+                _networkTokenGovernance.mint(address(this), delta - networkBalance);
             }
 
             // lock network tokens for the caller
-            networkTokenLocal.safeTransfer(address(wallet), delta);
-            lockTokens(_provider, delta);
+            _networkToken.safeTransfer(address(_wallet), delta);
+            lockTokens(provider, delta);
         }
 
         // if the contract still holds network tokens, burn them
-        uint256 networkBalance = networkTokenLocal.balanceOf(address(this));
+        uint256 networkBalance = _networkToken.balanceOf(address(this));
         if (networkBalance > 0) {
             burnNetworkTokens(liquidity.poolToken, networkBalance);
         }
@@ -752,57 +786,58 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      * it's also possible to provide the remove liquidity rate & time to get an estimation
      * for the return at that given point
      *
-     * @param _poolToken       pool token
-     * @param _reserveToken    reserve token
-     * @param _poolAmount      pool token amount when the liquidity was added
-     * @param _reserveAmount   reserve token amount that was added
-     * @param _packedRates     see `struct PackedRates`
-     * @param _addTimestamp    time at which the liquidity was added
-     * @param _removeTimestamp time at which the liquidity is removed
+     * @param poolToken pool token
+     * @param reserveToken reserve token
+     * @param poolAmount pool token amount when the liquidity was added
+     * @param reserveAmount reserve token amount that was added
+     * @param packedRates see `struct PackedRates`
+     * @param addTimestamp time at which the liquidity was added
+     * @param removeTimestamp time at which the liquidity is removed
+     *
      * @return amount received for removing liquidity
      */
     function removeLiquidityTargetAmount(
-        IDSToken _poolToken,
-        IERC20 _reserveToken,
-        uint256 _poolAmount,
-        uint256 _reserveAmount,
-        PackedRates memory _packedRates,
-        uint256 _addTimestamp,
-        uint256 _removeTimestamp
+        IDSToken poolToken,
+        IERC20 reserveToken,
+        uint256 poolAmount,
+        uint256 reserveAmount,
+        PackedRates memory packedRates,
+        uint256 addTimestamp,
+        uint256 removeTimestamp
     ) internal view returns (uint256) {
         // get the rate between the pool token and the reserve token
-        Fraction memory poolRate = poolTokenRate(_poolToken, _reserveToken);
+        Fraction memory poolRate = poolTokenRate(poolToken, reserveToken);
 
         // get the rate between the reserves upon adding liquidity and now
-        Fraction memory addSpotRate = Fraction({ n: _packedRates.addSpotRateN, d: _packedRates.addSpotRateD });
-        Fraction memory removeSpotRate = Fraction({ n: _packedRates.removeSpotRateN, d: _packedRates.removeSpotRateD });
+        Fraction memory addSpotRate = Fraction({ n: packedRates.addSpotRateN, d: packedRates.addSpotRateD });
+        Fraction memory removeSpotRate = Fraction({ n: packedRates.removeSpotRateN, d: packedRates.removeSpotRateD });
         Fraction memory removeAverageRate =
-            Fraction({ n: _packedRates.removeAverageRateN, d: _packedRates.removeAverageRateD });
+            Fraction({ n: packedRates.removeAverageRateN, d: packedRates.removeAverageRateD });
 
         // calculate the protected amount of reserve tokens plus accumulated fee before compensation
-        uint256 total = protectedAmountPlusFee(_poolAmount, poolRate, addSpotRate, removeSpotRate);
+        uint256 total = protectedAmountPlusFee(poolAmount, poolRate, addSpotRate, removeSpotRate);
 
         // calculate the impermanent loss
         Fraction memory loss = impLoss(addSpotRate, removeAverageRate);
 
         // calculate the protection level
-        Fraction memory level = protectionLevel(_addTimestamp, _removeTimestamp);
+        Fraction memory level = protectionLevel(addTimestamp, removeTimestamp);
 
         // calculate the compensation amount
-        return compensationAmount(_reserveAmount, MathEx.max(_reserveAmount, total), loss, level);
+        return compensationAmount(reserveAmount, MathEx.max(reserveAmount, total), loss, level);
     }
 
     /**
      * @dev allows the caller to claim network token balance that is no longer locked
      * note that the function can revert if the range is too large
      *
-     * @param _startIndex  start index in the caller's list of locked balances
-     * @param _endIndex    end index in the caller's list of locked balances (exclusive)
+     * @param startIndex start index in the caller's list of locked balances
+     * @param endIndex end index in the caller's list of locked balances (exclusive)
      */
-    function claimBalance(uint256 _startIndex, uint256 _endIndex) external protected {
+    function claimBalance(uint256 startIndex, uint256 endIndex) external protected {
         // get the locked balances from the store
         (uint256[] memory amounts, uint256[] memory expirationTimes) =
-            store.lockedBalanceRange(msg.sender, _startIndex, _endIndex);
+            _store.lockedBalanceRange(msg.sender, startIndex, endIndex);
 
         uint256 totalAmount = 0;
         uint256 length = amounts.length;
@@ -816,13 +851,13 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
             }
 
             // remove the locked balance item
-            store.removeLockedBalance(msg.sender, _startIndex + index);
+            _store.removeLockedBalance(msg.sender, startIndex + index);
             totalAmount = totalAmount.add(amounts[index]);
         }
 
         if (totalAmount > 0) {
             // transfer the tokens to the caller in a single call
-            wallet.withdrawTokens(networkToken, msg.sender, totalAmount);
+            _wallet.withdrawTokens(_networkToken, msg.sender, totalAmount);
         }
     }
 
@@ -831,89 +866,91 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      * the function assumes full protection is in effect
      * return value is in PPM and can be larger than PPM_RESOLUTION for positive ROI, 1M = 0% ROI
      *
-     * @param _poolToken       pool token
-     * @param _reserveToken    reserve token
-     * @param _reserveAmount   reserve token amount that was added
-     * @param _poolRateN       rate of 1 pool token in reserve token units when the liquidity was added (numerator)
-     * @param _poolRateD       rate of 1 pool token in reserve token units when the liquidity was added (denominator)
-     * @param _reserveRateN    rate of 1 reserve token in the other reserve token units when the liquidity was added (numerator)
-     * @param _reserveRateD    rate of 1 reserve token in the other reserve token units when the liquidity was added (denominator)
+     * @param poolToken pool token
+     * @param reserveToken reserve token
+     * @param reserveAmount reserve token amount that was added
+     * @param poolRateN rate of 1 pool token in reserve token units when the liquidity was added (numerator)
+     * @param poolRateD rate of 1 pool token in reserve token units when the liquidity was added (denominator)
+     * @param reserveRateN rate of 1 reserve token in the other reserve token units when the liquidity was added (numerator)
+     * @param reserveRateD rate of 1 reserve token in the other reserve token units when the liquidity was added (denominator)
+     *
      * @return ROI in PPM
      */
     function poolROI(
-        IDSToken _poolToken,
-        IERC20 _reserveToken,
-        uint256 _reserveAmount,
-        uint256 _poolRateN,
-        uint256 _poolRateD,
-        uint256 _reserveRateN,
-        uint256 _reserveRateD
+        IDSToken poolToken,
+        IERC20 reserveToken,
+        uint256 reserveAmount,
+        uint256 poolRateN,
+        uint256 poolRateD,
+        uint256 reserveRateN,
+        uint256 reserveRateD
     ) external view returns (uint256) {
         // calculate the amount of pool tokens based on the amount of reserve tokens
-        uint256 poolAmount = _reserveAmount.mul(_poolRateD).div(_poolRateN);
+        uint256 poolAmount = reserveAmount.mul(poolRateD).div(poolRateN);
 
         // get the various rates between the reserves upon adding liquidity and now
-        PackedRates memory packedRates = packRates(_poolToken, _reserveToken, _reserveRateN, _reserveRateD, false);
+        PackedRates memory packedRates = packRates(poolToken, reserveToken, reserveRateN, reserveRateD, false);
 
         // get the current return
         uint256 protectedReturn =
             removeLiquidityTargetAmount(
-                _poolToken,
-                _reserveToken,
+                poolToken,
+                reserveToken,
                 poolAmount,
-                _reserveAmount,
+                reserveAmount,
                 packedRates,
-                time().sub(settings.maxProtectionDelay()),
+                time().sub(_settings.maxProtectionDelay()),
                 time()
             );
 
         // calculate the ROI as the ratio between the current fully protected return and the initial amount
-        return protectedReturn.mul(PPM_RESOLUTION).div(_reserveAmount);
+        return protectedReturn.mul(PPM_RESOLUTION).div(reserveAmount);
     }
 
     /**
      * @dev adds protected liquidity for the caller to the store
      *
-     * @param _provider        protected liquidity provider
-     * @param _poolToken       pool token
-     * @param _reserveToken    reserve token
-     * @param _poolAmount      amount of pool tokens to protect
-     * @param _reserveAmount   amount of reserve tokens to protect
+     * @param provider protected liquidity provider
+     * @param poolToken pool token
+     * @param reserveToken reserve token
+     * @param poolAmount amount of pool tokens to protect
+     * @param reserveAmount amount of reserve tokens to protect
+     *
      * @return new protected liquidity id
      */
     function addProtectedLiquidity(
-        address _provider,
-        IDSToken _poolToken,
-        IERC20 _reserveToken,
-        uint256 _poolAmount,
-        uint256 _reserveAmount
+        address provider,
+        IDSToken poolToken,
+        IERC20 reserveToken,
+        uint256 poolAmount,
+        uint256 reserveAmount
     ) internal returns (uint256) {
         // notify event subscribers
-        address[] memory subscribers = settings.subscribers();
+        address[] memory subscribers = _settings.subscribers();
         uint256 length = subscribers.length;
         for (uint256 i = 0; i < length; i++) {
             ILiquidityProtectionEventsSubscriber(subscribers[i]).onAddingLiquidity(
-                _provider,
-                _poolToken,
-                _reserveToken,
-                _poolAmount,
-                _reserveAmount
+                provider,
+                poolToken,
+                reserveToken,
+                poolAmount,
+                reserveAmount
             );
         }
 
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(_poolToken)));
-        IERC20 otherReserve = converterOtherReserve(converter, _reserveToken);
-        (uint256 rateN, uint256 rateD) = converterReserveBalances(converter, otherReserve, _reserveToken);
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolToken)));
+        IERC20 otherReserve = converterOtherReserve(converter, reserveToken);
+        (uint256 rateN, uint256 rateD) = converterReserveBalances(converter, otherReserve, reserveToken);
 
-        stats.increaseTotalAmounts(_provider, _poolToken, _reserveToken, _poolAmount, _reserveAmount);
-        stats.addProviderPool(_provider, _poolToken);
+        _stats.increaseTotalAmounts(provider, poolToken, reserveToken, poolAmount, reserveAmount);
+        _stats.addProviderPool(provider, poolToken);
         return
-            store.addProtectedLiquidity(
-                _provider,
-                _poolToken,
-                _reserveToken,
-                _poolAmount,
-                _reserveAmount,
+            _store.addProtectedLiquidity(
+                provider,
+                poolToken,
+                reserveToken,
+                poolAmount,
+                reserveAmount,
                 rateN,
                 rateD,
                 time()
@@ -923,27 +960,27 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     /**
      * @dev locks network tokens for the provider and emits the tokens locked event
      *
-     * @param _provider    tokens provider
-     * @param _amount      amount of network tokens
+     * @param provider tokens provider
+     * @param amount amount of network tokens
      */
-    function lockTokens(address _provider, uint256 _amount) internal {
-        uint256 expirationTime = time().add(settings.lockDuration());
-        store.addLockedBalance(_provider, _amount, expirationTime);
+    function lockTokens(address provider, uint256 amount) internal {
+        uint256 expirationTime = time().add(_settings.lockDuration());
+        _store.addLockedBalance(provider, amount, expirationTime);
     }
 
     /**
      * @dev returns the rate of 1 pool token in reserve token units
      *
-     * @param _poolToken       pool token
-     * @param _reserveToken    reserve token
+     * @param poolToken pool token
+     * @param reserveToken reserve token
      */
-    function poolTokenRate(IDSToken _poolToken, IERC20 _reserveToken) internal view virtual returns (Fraction memory) {
+    function poolTokenRate(IDSToken poolToken, IERC20 reserveToken) internal view virtual returns (Fraction memory) {
         // get the pool token supply
-        uint256 poolTokenSupply = _poolToken.totalSupply();
+        uint256 poolTokenSupply = poolToken.totalSupply();
 
         // get the reserve balance
-        IConverter converter = IConverter(payable(ownedBy(_poolToken)));
-        uint256 reserveBalance = converter.getConnectorBalance(_reserveToken);
+        IConverter converter = IConverter(payable(ownedBy(poolToken)));
+        uint256 reserveBalance = converter.getConnectorBalance(reserveToken);
 
         // for standard pools, 50% of the pool supply value equals the value of each reserve
         return Fraction({ n: reserveBalance.mul(2), d: poolTokenSupply });
@@ -952,14 +989,14 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     /**
      * @dev returns the spot rate and average rate of 1 reserve token in the other reserve token units
      *
-     * @param _poolToken            pool token
-     * @param _reserveToken         reserve token
-     * @param _validateAverageRate  true to validate the average rate; false otherwise
+     * @param poolToken pool token
+     * @param reserveToken reserve token
+     * @param validateAverageRate true to validate the average rate; false otherwise
      */
     function reserveTokenRates(
-        IDSToken _poolToken,
-        IERC20 _reserveToken,
-        bool _validateAverageRate
+        IDSToken poolToken,
+        IERC20 reserveToken,
+        bool validateAverageRate
     )
         internal
         view
@@ -970,20 +1007,20 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
             uint256
         )
     {
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(_poolToken)));
-        IERC20 otherReserve = converterOtherReserve(converter, _reserveToken);
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolToken)));
+        IERC20 otherReserve = converterOtherReserve(converter, reserveToken);
 
-        (uint256 spotRateN, uint256 spotRateD) = converterReserveBalances(converter, otherReserve, _reserveToken);
-        (uint256 averageRateN, uint256 averageRateD) = converter.recentAverageRate(_reserveToken);
+        (uint256 spotRateN, uint256 spotRateD) = converterReserveBalances(converter, otherReserve, reserveToken);
+        (uint256 averageRateN, uint256 averageRateD) = converter.recentAverageRate(reserveToken);
 
         require(
-            !_validateAverageRate ||
+            !validateAverageRate ||
                 averageRateInRange(
                     spotRateN,
                     spotRateD,
                     averageRateN,
                     averageRateD,
-                    settings.averageRateMaxDeviation()
+                    _settings.averageRateMaxDeviation()
                 ),
             "ERR_INVALID_RATE"
         );
@@ -994,25 +1031,25 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     /**
      * @dev returns the various rates between the reserves
      *
-     * @param _poolToken            pool token
-     * @param _reserveToken         reserve token
-     * @param _addSpotRateN         add spot rate numerator
-     * @param _addSpotRateD         add spot rate denominator
-     * @param _validateAverageRate  true to validate the average rate; false otherwise
+     * @param poolToken pool token
+     * @param reserveToken reserve token
+     * @param addSpotRateN add spot rate numerator
+     * @param addSpotRateD add spot rate denominator
+     * @param validateAverageRate true to validate the average rate; false otherwise
      * @return see `struct PackedRates`
      */
     function packRates(
-        IDSToken _poolToken,
-        IERC20 _reserveToken,
-        uint256 _addSpotRateN,
-        uint256 _addSpotRateD,
-        bool _validateAverageRate
+        IDSToken poolToken,
+        IERC20 reserveToken,
+        uint256 addSpotRateN,
+        uint256 addSpotRateD,
+        bool validateAverageRate
     ) internal view returns (PackedRates memory) {
         (uint256 removeSpotRateN, uint256 removeSpotRateD, uint256 removeAverageRateN, uint256 removeAverageRateD) =
-            reserveTokenRates(_poolToken, _reserveToken, _validateAverageRate);
+            reserveTokenRates(poolToken, reserveToken, validateAverageRate);
 
         require(
-            (_addSpotRateN <= MAX_UINT128 && _addSpotRateD <= MAX_UINT128) &&
+            (addSpotRateN <= MAX_UINT128 && addSpotRateD <= MAX_UINT128) &&
                 (removeSpotRateN <= MAX_UINT128 && removeSpotRateD <= MAX_UINT128) &&
                 (removeAverageRateN <= MAX_UINT128 && removeAverageRateD <= MAX_UINT128),
             "ERR_INVALID_RATE"
@@ -1020,8 +1057,8 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
 
         return
             PackedRates({
-                addSpotRateN: uint128(_addSpotRateN),
-                addSpotRateD: uint128(_addSpotRateD),
+                addSpotRateN: uint128(addSpotRateN),
+                addSpotRateD: uint128(addSpotRateD),
                 removeSpotRateN: uint128(removeSpotRateN),
                 removeSpotRateD: uint128(removeSpotRateD),
                 removeAverageRateN: uint128(removeAverageRateN),
@@ -1033,54 +1070,54 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      * @dev returns whether or not the deviation of the average rate from the spot rate is within range
      * for example, if the maximum permitted deviation is 5%, then return `95/100 <= average/spot <= 100/95`
      *
-     * @param _spotRateN       spot rate numerator
-     * @param _spotRateD       spot rate denominator
-     * @param _averageRateN    average rate numerator
-     * @param _averageRateD    average rate denominator
-     * @param _maxDeviation    the maximum permitted deviation of the average rate from the spot rate
+     * @param spotRateN spot rate numerator
+     * @param spotRateD spot rate denominator
+     * @param averageRateN average rate numerator
+     * @param averageRateD average rate denominator
+     * @param maxDeviation the maximum permitted deviation of the average rate from the spot rate
      */
     function averageRateInRange(
-        uint256 _spotRateN,
-        uint256 _spotRateD,
-        uint256 _averageRateN,
-        uint256 _averageRateD,
-        uint32 _maxDeviation
+        uint256 spotRateN,
+        uint256 spotRateD,
+        uint256 averageRateN,
+        uint256 averageRateD,
+        uint32 maxDeviation
     ) internal pure returns (bool) {
-        uint256 ppmDelta = PPM_RESOLUTION - _maxDeviation;
-        uint256 min = _spotRateN.mul(_averageRateD).mul(ppmDelta).mul(ppmDelta);
-        uint256 mid = _spotRateD.mul(_averageRateN).mul(ppmDelta).mul(PPM_RESOLUTION);
-        uint256 max = _spotRateN.mul(_averageRateD).mul(PPM_RESOLUTION).mul(PPM_RESOLUTION);
+        uint256 ppmDelta = PPM_RESOLUTION - maxDeviation;
+        uint256 min = spotRateN.mul(averageRateD).mul(ppmDelta).mul(ppmDelta);
+        uint256 mid = spotRateD.mul(averageRateN).mul(ppmDelta).mul(PPM_RESOLUTION);
+        uint256 max = spotRateN.mul(averageRateD).mul(PPM_RESOLUTION).mul(PPM_RESOLUTION);
         return min <= mid && mid <= max;
     }
 
     /**
      * @dev utility to add liquidity to a converter
      *
-     * @param _converter       converter
-     * @param _reserveToken1   reserve token 1
-     * @param _reserveToken2   reserve token 2
-     * @param _reserveAmount1  reserve amount 1
-     * @param _reserveAmount2  reserve amount 2
-     * @param _value           ETH amount to add
+     * @param converter converter
+     * @param reserveToken1 reserve token 1
+     * @param reserveToken2 reserve token 2
+     * @param reserveAmount1 reserve amount 1
+     * @param reserveAmount2 reserve amount 2
+     * @param value ETH amount to add
      */
     function addLiquidity(
-        ILiquidityPoolConverter _converter,
-        IERC20 _reserveToken1,
-        IERC20 _reserveToken2,
-        uint256 _reserveAmount1,
-        uint256 _reserveAmount2,
-        uint256 _value
+        ILiquidityPoolConverter converter,
+        IERC20 reserveToken1,
+        IERC20 reserveToken2,
+        uint256 reserveAmount1,
+        uint256 reserveAmount2,
+        uint256 value
     ) internal {
         // ensure that the contract can receive ETH
         updatingLiquidity = true;
 
         IERC20[] memory reserveTokens = new IERC20[](2);
         uint256[] memory amounts = new uint256[](2);
-        reserveTokens[0] = _reserveToken1;
-        reserveTokens[1] = _reserveToken2;
-        amounts[0] = _reserveAmount1;
-        amounts[1] = _reserveAmount2;
-        _converter.addLiquidity{ value: _value }(reserveTokens, amounts, 1);
+        reserveTokens[0] = reserveToken1;
+        reserveTokens[1] = reserveToken2;
+        amounts[0] = reserveAmount1;
+        amounts[1] = reserveAmount2;
+        converter.addLiquidity{ value: value }(reserveTokens, amounts, 1);
 
         // ensure that the contract can receive ETH
         updatingLiquidity = false;
@@ -1089,29 +1126,29 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     /**
      * @dev utility to remove liquidity from a converter
      *
-     * @param _poolToken       pool token of the converter
-     * @param _poolAmount      amount of pool tokens to remove
-     * @param _reserveToken1   reserve token 1
-     * @param _reserveToken2   reserve token 2
+     * @param poolToken pool token of the converter
+     * @param poolAmount amount of pool tokens to remove
+     * @param reserveToken1 reserve token 1
+     * @param reserveToken2 reserve token 2
      */
     function removeLiquidity(
-        IDSToken _poolToken,
-        uint256 _poolAmount,
-        IERC20 _reserveToken1,
-        IERC20 _reserveToken2
+        IDSToken poolToken,
+        uint256 poolAmount,
+        IERC20 reserveToken1,
+        IERC20 reserveToken2
     ) internal {
-        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(_poolToken)));
+        ILiquidityPoolConverter converter = ILiquidityPoolConverter(payable(ownedBy(poolToken)));
 
         // ensure that the contract can receive ETH
         updatingLiquidity = true;
 
         IERC20[] memory reserveTokens = new IERC20[](2);
         uint256[] memory minReturns = new uint256[](2);
-        reserveTokens[0] = _reserveToken1;
-        reserveTokens[1] = _reserveToken2;
+        reserveTokens[0] = reserveToken1;
+        reserveTokens[1] = reserveToken2;
         minReturns[0] = 1;
         minReturns[1] = 1;
-        converter.removeLiquidity(_poolAmount, reserveTokens, minReturns);
+        converter.removeLiquidity(poolAmount, reserveTokens, minReturns);
 
         // ensure that the contract can receive ETH
         updatingLiquidity = false;
@@ -1120,10 +1157,11 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     /**
      * @dev returns a protected liquidity from the store
      *
-     * @param _id  protected liquidity id
+     * @param id protected liquidity id
+     *
      * @return protected liquidity
      */
-    function protectedLiquidity(uint256 _id) internal view returns (ProtectedLiquidity memory) {
+    function protectedLiquidity(uint256 id) internal view returns (ProtectedLiquidity memory) {
         ProtectedLiquidity memory liquidity;
         (
             liquidity.provider,
@@ -1134,7 +1172,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
             liquidity.reserveRateN,
             liquidity.reserveRateD,
             liquidity.timestamp
-        ) = store.protectedLiquidity(_id);
+        ) = _store.protectedLiquidity(id);
 
         return liquidity;
     }
@@ -1142,40 +1180,43 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     /**
      * @dev returns a protected liquidity from the store
      *
-     * @param _id          protected liquidity id
-     * @param _provider    authorized provider
+     * @param id protected liquidity id
+     * @param provider authorized provider
+     *
      * @return protected liquidity
      */
-    function protectedLiquidity(uint256 _id, address _provider) internal view returns (ProtectedLiquidity memory) {
-        ProtectedLiquidity memory liquidity = protectedLiquidity(_id);
-        require(liquidity.provider == _provider, "ERR_ACCESS_DENIED");
+    function protectedLiquidity(uint256 id, address provider) internal view returns (ProtectedLiquidity memory) {
+        ProtectedLiquidity memory liquidity = protectedLiquidity(id);
+        require(liquidity.provider == provider, "ERR_ACCESS_DENIED");
+
         return liquidity;
     }
 
     /**
      * @dev returns the protected amount of reserve tokens plus accumulated fee before compensation
      *
-     * @param _poolAmount      pool token amount when the liquidity was added
-     * @param _poolRate        rate of 1 pool token in the related reserve token units
-     * @param _addRate         rate of 1 reserve token in the other reserve token units when the liquidity was added
-     * @param _removeRate      rate of 1 reserve token in the other reserve token units when the liquidity is removed
-     * @return protected amount of reserve tokens plus accumulated fee = sqrt(_removeRate / _addRate) * _poolRate * _poolAmount
+     * @param poolAmount pool token amount when the liquidity was added
+     * @param poolRate rate of 1 pool token in the related reserve token units
+     * @param addRate rate of 1 reserve token in the other reserve token units when the liquidity was added
+     * @param removeRate rate of 1 reserve token in the other reserve token units when the liquidity is removed
+     *
+     * @return protected amount of reserve tokens plus accumulated fee = sqrt(removeRate / addRate) * poolRate * poolAmount
      */
     function protectedAmountPlusFee(
-        uint256 _poolAmount,
-        Fraction memory _poolRate,
-        Fraction memory _addRate,
-        Fraction memory _removeRate
+        uint256 poolAmount,
+        Fraction memory poolRate,
+        Fraction memory addRate,
+        Fraction memory removeRate
     ) internal pure returns (uint256) {
-        uint256 n = MathEx.ceilSqrt(_addRate.d.mul(_removeRate.n)).mul(_poolRate.n);
-        uint256 d = MathEx.floorSqrt(_addRate.n.mul(_removeRate.d)).mul(_poolRate.d);
+        uint256 n = MathEx.ceilSqrt(addRate.d.mul(removeRate.n)).mul(poolRate.n);
+        uint256 d = MathEx.floorSqrt(addRate.n.mul(removeRate.d)).mul(poolRate.d);
 
-        uint256 x = n * _poolAmount;
-        if (x / n == _poolAmount) {
+        uint256 x = n * poolAmount;
+        if (x / n == poolAmount) {
             return x / d;
         }
 
-        (uint256 hi, uint256 lo) = n > _poolAmount ? (n, _poolAmount) : (_poolAmount, n);
+        (uint256 hi, uint256 lo) = n > poolAmount ? (n, poolAmount) : (poolAmount, n);
         (uint256 p, uint256 q) = MathEx.reducedRatio(hi, d, MAX_UINT256 / lo);
         uint256 min = (hi / d).mul(lo);
 
@@ -1188,13 +1229,13 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     /**
      * @dev returns the impermanent loss incurred due to the change in rates between the reserve tokens
      *
-     * @param _prevRate    previous rate between the reserves
-     * @param _newRate     new rate between the reserves
+     * @param prevRate previous rate between the reserves
+     * @param newRate new rate between the reserves
      * @return impermanent loss (as a ratio)
      */
-    function impLoss(Fraction memory _prevRate, Fraction memory _newRate) internal pure returns (Fraction memory) {
-        uint256 ratioN = _newRate.n.mul(_prevRate.d);
-        uint256 ratioD = _newRate.d.mul(_prevRate.n);
+    function impLoss(Fraction memory prevRate, Fraction memory newRate) internal pure returns (Fraction memory) {
+        uint256 ratioN = newRate.n.mul(prevRate.d);
+        uint256 ratioD = newRate.d.mul(prevRate.n);
 
         uint256 prod = ratioN * ratioD;
         uint256 root =
@@ -1212,14 +1253,15 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     /**
      * @dev returns the protection level based on the timestamp and protection delays
      *
-     * @param _addTimestamp    time at which the liquidity was added
-     * @param _removeTimestamp time at which the liquidity is removed
+     * @param addTimestamp time at which the liquidity was added
+     * @param removeTimestamp time at which the liquidity is removed
+     *
      * @return protection level (as a ratio)
      */
-    function protectionLevel(uint256 _addTimestamp, uint256 _removeTimestamp) internal view returns (Fraction memory) {
-        uint256 timeElapsed = _removeTimestamp.sub(_addTimestamp);
-        uint256 minProtectionDelay = settings.minProtectionDelay();
-        uint256 maxProtectionDelay = settings.maxProtectionDelay();
+    function protectionLevel(uint256 addTimestamp, uint256 removeTimestamp) internal view returns (Fraction memory) {
+        uint256 timeElapsed = removeTimestamp.sub(addTimestamp);
+        uint256 minProtectionDelay = _settings.minProtectionDelay();
+        uint256 maxProtectionDelay = _settings.maxProtectionDelay();
         if (timeElapsed < minProtectionDelay) {
             return Fraction({ n: 0, d: 1 });
         }
@@ -1234,41 +1276,42 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     /**
      * @dev returns the compensation amount based on the impermanent loss and the protection level
      *
-     * @param _amount  protected amount in units of the reserve token
-     * @param _total   amount plus fee in units of the reserve token
-     * @param _loss    protection level (as a ratio between 0 and 1)
-     * @param _level   impermanent loss (as a ratio between 0 and 1)
+     * @param amount protected amount in units of the reserve token
+     * @param total amount plus fee in units of the reserve token
+     * @param loss protection level (as a ratio between 0 and 1)
+     * @param level impermanent loss (as a ratio between 0 and 1)
+     *
      * @return compensation amount
      */
     function compensationAmount(
-        uint256 _amount,
-        uint256 _total,
-        Fraction memory _loss,
-        Fraction memory _level
+        uint256 amount,
+        uint256 total,
+        Fraction memory loss,
+        Fraction memory level
     ) internal pure returns (uint256) {
-        uint256 levelN = _level.n.mul(_amount);
-        uint256 levelD = _level.d;
-        uint256 maxVal = MathEx.max(MathEx.max(levelN, levelD), _total);
-        (uint256 lossN, uint256 lossD) = MathEx.reducedRatio(_loss.n, _loss.d, MAX_UINT256 / maxVal);
-        return _total.mul(lossD.sub(lossN)).div(lossD).add(lossN.mul(levelN).div(lossD.mul(levelD)));
+        uint256 levelN = level.n.mul(amount);
+        uint256 levelD = level.d;
+        uint256 maxVal = MathEx.max(MathEx.max(levelN, levelD), total);
+        (uint256 lossN, uint256 lossD) = MathEx.reducedRatio(loss.n, loss.d, MAX_UINT256 / maxVal);
+        return total.mul(lossD.sub(lossN)).div(lossD).add(lossN.mul(levelN).div(lossD.mul(levelD)));
     }
 
-    function getNetworkCompensation(
-        uint256 _targetAmount,
-        uint256 _baseAmount,
-        PackedRates memory _packedRates
+    function networkCompensation(
+        uint256 targetAmount,
+        uint256 baseAmount,
+        PackedRates memory packedRates
     ) internal view returns (uint256) {
-        if (_targetAmount <= _baseAmount) {
+        if (targetAmount <= baseAmount) {
             return 0;
         }
 
         // calculate the delta in network tokens
         uint256 delta =
-            (_targetAmount - _baseAmount).mul(_packedRates.removeAverageRateN).div(_packedRates.removeAverageRateD);
+            (targetAmount - baseAmount).mul(packedRates.removeAverageRateN).div(packedRates.removeAverageRateD);
 
         // the delta might be very small due to precision loss
         // in which case no compensation will take place (gas optimization)
-        if (delta >= settings.minNetworkCompensation()) {
+        if (delta >= _settings.minNetworkCompensation()) {
             return delta;
         }
 
@@ -1280,80 +1323,80 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      * note that we use the non standard erc-20 interface in which `approve` has no return value so that
      * this function will work for both standard and non standard tokens
      *
-     * @param _token   token to check the allowance in
-     * @param _spender approved address
-     * @param _value   allowance amount
+     * @param token token to check the allowance in
+     * @param spender approved address
+     * @param value allowance amount
      */
     function ensureAllowance(
-        IERC20 _token,
-        address _spender,
-        uint256 _value
+        IERC20 token,
+        address spender,
+        uint256 value
     ) private {
-        uint256 allowance = _token.allowance(address(this), _spender);
-        if (allowance < _value) {
+        uint256 allowance = token.allowance(address(this), spender);
+        if (allowance < value) {
             if (allowance > 0) {
-                _token.safeApprove(_spender, 0);
+                token.safeApprove(spender, 0);
             }
-            _token.safeApprove(_spender, _value);
+            token.safeApprove(spender, value);
         }
     }
 
     // utility to mint network tokens
     function mintNetworkTokens(
-        address _owner,
-        IConverterAnchor _poolAnchor,
-        uint256 _amount
+        address owner,
+        IConverterAnchor poolAnchor,
+        uint256 amount
     ) private {
-        networkTokenGovernance.mint(_owner, _amount);
-        systemStore.incNetworkTokensMinted(_poolAnchor, _amount);
+        _networkTokenGovernance.mint(owner, amount);
+        _systemStore.incNetworkTokensMinted(poolAnchor, amount);
     }
 
     // utility to burn network tokens
-    function burnNetworkTokens(IConverterAnchor _poolAnchor, uint256 _amount) private {
-        networkTokenGovernance.burn(_amount);
-        systemStore.decNetworkTokensMinted(_poolAnchor, _amount);
+    function burnNetworkTokens(IConverterAnchor poolAnchor, uint256 amount) private {
+        _networkTokenGovernance.burn(amount);
+        _systemStore.decNetworkTokensMinted(poolAnchor, amount);
     }
 
     // utility to notify event subscribers on removing liquidity
     function notifyEventSubscribersOnRemovingLiquidity(
-        uint256 _id,
-        address _provider,
-        IDSToken _poolToken,
-        IERC20 _reserveToken,
-        uint256 _poolAmount,
-        uint256 _reserveAmount
+        uint256 id,
+        address provider,
+        IDSToken poolToken,
+        IERC20 reserveToken,
+        uint256 poolAmount,
+        uint256 reserveAmount
     ) private {
-        address[] memory subscribers = settings.subscribers();
+        address[] memory subscribers = _settings.subscribers();
         uint256 length = subscribers.length;
         for (uint256 i = 0; i < length; i++) {
             ILiquidityProtectionEventsSubscriber(subscribers[i]).onRemovingLiquidity(
-                _id,
-                _provider,
-                _poolToken,
-                _reserveToken,
-                _poolAmount,
-                _reserveAmount
+                id,
+                provider,
+                poolToken,
+                reserveToken,
+                poolAmount,
+                reserveAmount
             );
         }
     }
 
     // utility to get the reserve balances
     function converterReserveBalances(
-        IConverter _converter,
-        IERC20 _reserveToken1,
-        IERC20 _reserveToken2
+        IConverter converter,
+        IERC20 reserveToken1,
+        IERC20 reserveToken2
     ) private view returns (uint256, uint256) {
-        return (_converter.getConnectorBalance(_reserveToken1), _converter.getConnectorBalance(_reserveToken2));
+        return (converter.getConnectorBalance(reserveToken1), converter.getConnectorBalance(reserveToken2));
     }
 
     // utility to get the other reserve
-    function converterOtherReserve(IConverter _converter, IERC20 _thisReserve) private view returns (IERC20) {
-        IERC20 otherReserve = _converter.connectorTokens(0);
-        return otherReserve != _thisReserve ? otherReserve : _converter.connectorTokens(1);
+    function converterOtherReserve(IConverter converter, IERC20 thisReserve) private view returns (IERC20) {
+        IERC20 otherReserve = converter.connectorTokens(0);
+        return otherReserve != thisReserve ? otherReserve : converter.connectorTokens(1);
     }
 
     // utility to get the owner
-    function ownedBy(IOwned _owned) private view returns (address) {
-        return _owned.owner();
+    function ownedBy(IOwned owned) private view returns (address) {
+        return owned.owner();
     }
 }

--- a/solidity/contracts/liquidity-protection/LiquidityProtection.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtection.sol
@@ -85,32 +85,44 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
     /**
      * @dev initializes a new LiquidityProtection contract
      *
-     * @param _contractAddresses:
-     * - [0] liquidity protection settings
-     * - [1] liquidity protection store
-     * - [2] liquidity protection stats
-     * - [3] liquidity protection system store
-     * - [4] liquidity protection wallet
-     * - [5] network token governance
-     * - [6] governance token governance
-     * - [7] last liquidity removal/unprotection checkpoints store
+     * @param settings liquidity protection settings
+     * @param store liquidity protection store
+     * @param stats liquidity protection stats
+     * @param systemStore liquidity protection system store
+     * @param wallet liquidity protection wallet
+     * @param networkTokenGovernance network token governance
+     * @param govTokenGovernance governance token governance
+     * @param lastRemoveCheckpointStore last liquidity removal/unprotection checkpoints store
      */
-    constructor(address[8] memory _contractAddresses) public {
-        for (uint256 i = 0; i < _contractAddresses.length; i++) {
-            _validAddress(_contractAddresses[i]);
-        }
+    constructor(
+        ILiquidityProtectionSettings settings,
+        ILiquidityProtectionStore store,
+        ILiquidityProtectionStats stats,
+        ILiquidityProtectionSystemStore systemStore,
+        ITokenHolder wallet,
+        ITokenGovernance networkTokenGovernance,
+        ITokenGovernance govTokenGovernance,
+        ICheckpointStore lastRemoveCheckpointStore
+    )
+        public
+        validAddress(address(settings))
+        validAddress(address(store))
+        validAddress(address(stats))
+        validAddress(address(systemStore))
+        validAddress(address(wallet))
+        validAddress(address(lastRemoveCheckpointStore))
+    {
+        _settings = settings;
+        _store = store;
+        _stats = stats;
+        _systemStore = systemStore;
+        _wallet = wallet;
+        _networkTokenGovernance = networkTokenGovernance;
+        _govTokenGovernance = govTokenGovernance;
+        _lastRemoveCheckpointStore = lastRemoveCheckpointStore;
 
-        _settings = ILiquidityProtectionSettings(_contractAddresses[0]);
-        _store = ILiquidityProtectionStore(_contractAddresses[1]);
-        _stats = ILiquidityProtectionStats(_contractAddresses[2]);
-        _systemStore = ILiquidityProtectionSystemStore(_contractAddresses[3]);
-        _wallet = ITokenHolder(payable(_contractAddresses[4]));
-        _networkTokenGovernance = ITokenGovernance(_contractAddresses[5]);
-        _govTokenGovernance = ITokenGovernance(_contractAddresses[6]);
-        _lastRemoveCheckpointStore = ICheckpointStore(_contractAddresses[7]);
-
-        _networkToken = ITokenGovernance(_contractAddresses[5]).token();
-        _govToken = ITokenGovernance(_contractAddresses[6]).token();
+        _networkToken = networkTokenGovernance.token();
+        _govToken = govTokenGovernance.token();
     }
 
     // ensures that the pool is supported and whitelisted

--- a/solidity/test/LiquidityProtection.js
+++ b/solidity/test/LiquidityProtection.js
@@ -191,7 +191,7 @@ describe('LiquidityProtection', () => {
 
             const convert = async (path, amount, minReturn) => {
                 let token;
-                if (path[0] == baseTokenAddress) {
+                if (path[0] === baseTokenAddress) {
                     token = baseToken;
                 } else {
                     token = networkToken;
@@ -221,7 +221,7 @@ describe('LiquidityProtection', () => {
             const getRate = async (reserveAddress) => {
                 const reserve1Balance = await converter.reserveBalance(baseTokenAddress);
                 const reserve2Balance = await converter.reserveBalance(networkToken.address);
-                if (reserveAddress == baseTokenAddress) {
+                if (reserveAddress === baseTokenAddress) {
                     return { n: reserve2Balance, d: reserve1Balance };
                 }
 
@@ -230,13 +230,13 @@ describe('LiquidityProtection', () => {
 
             const increaseRate = async (reserveAddress) => {
                 let sourceAddress;
-                if (reserveAddress == baseTokenAddress) {
+                if (reserveAddress === baseTokenAddress) {
                     sourceAddress = networkToken.address;
                 } else {
                     sourceAddress = baseTokenAddress;
                 }
 
-                let path = [sourceAddress, poolToken.address, reserveAddress];
+                const path = [sourceAddress, poolToken.address, reserveAddress];
                 let amount = await converter.reserveBalance(networkToken.address);
                 amount = Decimal(2).sqrt().sub(1).mul(amount.toString());
                 amount = new BN(amount.floor().toFixed());
@@ -487,9 +487,10 @@ describe('LiquidityProtection', () => {
                     await baseToken.approve(liquidityProtection.address, TOTAL_SUPPLY);
                     await networkToken.approve(liquidityProtection.address, TOTAL_SUPPLY);
 
-                    const baseTokenAvailableSpace = await liquidityProtection.baseTokenAvailableSpace(
-                        poolToken.address
-                    );
+                    const poolTokenAvailableSpace = await liquidityProtection.poolAvailableSpace(poolToken.address);
+                    const baseTokenAvailableSpace = poolTokenAvailableSpace[0];
+                    const networkTokenAvailableSpace = poolTokenAvailableSpace[1];
+
                     await expectRevert(
                         liquidityProtection.addLiquidity(
                             poolToken.address,
@@ -504,9 +505,6 @@ describe('LiquidityProtection', () => {
                         baseTokenAvailableSpace
                     );
 
-                    const networkTokenAvailableSpace = await liquidityProtection.networkTokenAvailableSpace(
-                        poolToken.address
-                    );
                     await expectRevert(
                         liquidityProtection.addLiquidity(
                             poolToken.address,
@@ -702,6 +700,7 @@ describe('LiquidityProtection', () => {
                                     );
                                 });
 
+                                // eslint-disable-next-line max-len
                                 it('should revert when attempting to add liquidity when the pool has less liquidity than the minimum required', async () => {
                                     let reserveAmount = new BN(10000);
                                     await addProtectedLiquidity(
@@ -735,6 +734,7 @@ describe('LiquidityProtection', () => {
                                     );
                                 });
 
+                                // eslint-disable-next-line max-len
                                 it('should revert when attempting to add liquidity which will increase the system network token balance above the pool limit', async () => {
                                     let reserveAmount = new BN(10000);
                                     await addProtectedLiquidity(
@@ -965,13 +965,11 @@ describe('LiquidityProtection', () => {
                 it('verifies that removeLiquidityReturn returns the correct amount for removing entire protection', async () => {
                     const reserveAmount = new BN(1000);
                     await addProtectedLiquidity(poolToken.address, baseToken, baseTokenAddress, reserveAmount);
-                    let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
+                    const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
                     const protectionId = protectionIds[0];
-                    let protection = await liquidityProtectionStore.protectedLiquidity.call(protectionId);
-                    protection = getProtection(protection);
 
                     const amount = (
-                        await liquidityProtection.removeLiquidityReturn(protectionIds[0], PPM_RESOLUTION, now)
+                        await liquidityProtection.removeLiquidityReturn(protectionId, PPM_RESOLUTION, now)
                     )[0];
 
                     expect(amount).to.be.bignumber.equal(reserveAmount);
@@ -980,12 +978,10 @@ describe('LiquidityProtection', () => {
                 it('verifies that removeLiquidityReturn returns the correct amount for removing a portion of a protection', async () => {
                     const reserveAmount = new BN(1000);
                     await addProtectedLiquidity(poolToken.address, baseToken, baseTokenAddress, reserveAmount);
-                    let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
+                    const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
                     const protectionId = protectionIds[0];
-                    let protection = await liquidityProtectionStore.protectedLiquidity.call(protectionId);
-                    protection = getProtection(protection);
 
-                    const amount = (await liquidityProtection.removeLiquidityReturn(protectionIds[0], 800000, now))[0];
+                    const amount = (await liquidityProtection.removeLiquidityReturn(protectionId, 800000, now))[0];
 
                     expect(amount).to.be.bignumber.equal(new BN(800));
                 });
@@ -993,11 +989,12 @@ describe('LiquidityProtection', () => {
                 it('verifies that removeLiquidityReturn can be called even if the average rate is invalid', async () => {
                     const reserveAmount = new BN(1000);
                     await addProtectedLiquidity(poolToken.address, baseToken, baseTokenAddress, reserveAmount);
-                    let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
+                    const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
+                    const protectionId = protectionIds[0];
 
                     await increaseRate(baseTokenAddress);
                     await liquidityProtectionSettings.setAverageRateMaxDeviation(1);
-                    await liquidityProtection.removeLiquidityReturn(protectionIds[0], PPM_RESOLUTION, now);
+                    await liquidityProtection.removeLiquidityReturn(protectionId, PPM_RESOLUTION, now);
                 });
 
                 it('should revert when calling removeLiquidityReturn with zero portion of the liquidity', async () => {
@@ -1017,11 +1014,12 @@ describe('LiquidityProtection', () => {
                 it('should revert when calling removeLiquidityReturn with a date earlier than the protection deposit', async () => {
                     const reserveAmount = new BN(1000);
                     await addProtectedLiquidity(poolToken.address, baseToken, baseTokenAddress, reserveAmount);
-                    let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
+                    const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
+                    const protectionId = protectionIds[0];
 
                     await expectRevert(
                         liquidityProtection.removeLiquidityReturn(
-                            protectionIds[0],
+                            protectionId,
                             PPM_RESOLUTION,
                             now.sub(duration.years(1))
                         ),
@@ -1041,7 +1039,7 @@ describe('LiquidityProtection', () => {
                 beforeEach(async () => {
                     await addProtectedLiquidity(poolToken.address, baseToken, baseTokenAddress, new BN(20000));
                     await addProtectedLiquidity(poolToken.address, networkToken, networkToken.address, new BN(2000));
-                    let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
+                    const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
                     const protectionId = protectionIds[protectionIds.length - 1];
 
                     const portion = PPM_RESOLUTION.div(new BN(2));
@@ -1325,7 +1323,7 @@ describe('LiquidityProtection', () => {
                                 reserveAmount,
                                 isETHReserve
                             );
-                            let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
+                            const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
                             const protectionId = protectionIds[0];
 
                             await liquidityProtection.setTime(now.add(duration.seconds(1)));
@@ -1344,7 +1342,7 @@ describe('LiquidityProtection', () => {
                                 reserveAmount,
                                 isETHReserve
                             );
-                            let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
+                            const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
                             const protectionId = protectionIds[0];
 
                             await liquidityProtection.setTime(now.add(duration.seconds(1)));
@@ -1363,7 +1361,7 @@ describe('LiquidityProtection', () => {
                                 reserveAmount,
                                 isETHReserve
                             );
-                            let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
+                            const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(owner);
                             const protectionId = protectionIds[0];
 
                             await increaseRate(baseTokenAddress);
@@ -1384,7 +1382,7 @@ describe('LiquidityProtection', () => {
                         });
 
                         it('should revert when attempting to remove liquidity that belongs to another account', async () => {
-                            let reserveAmount = new BN(5000);
+                            const reserveAmount = new BN(5000);
                             await addProtectedLiquidity(
                                 poolToken.address,
                                 baseToken,
@@ -1406,7 +1404,7 @@ describe('LiquidityProtection', () => {
                         });
 
                         it('should revert when attempting to remove liquidity from a non whitelisted pool', async () => {
-                            let reserveAmount = new BN(5000);
+                            const reserveAmount = new BN(5000);
                             await addProtectedLiquidity(
                                 poolToken.address,
                                 baseToken,
@@ -1591,11 +1589,11 @@ describe('LiquidityProtection', () => {
                                 protection++
                             ) {
                                 context(
-                                    `(${reserve == 0 ? 'base token' : 'network token'}) with ${
+                                    `(${reserve === 0 ? 'base token' : 'network token'}) with ${
                                         protectionText[protection]
                                     } and ${rateChangeText[rateChange]} ${withFee ? 'with fee' : 'without fee'}`,
                                     () => {
-                                        let reserveAmount = new BN(5000);
+                                        const reserveAmount = new BN(5000);
                                         let reserveToken;
                                         let reserveAddress;
                                         let otherReserveAddress;
@@ -1613,7 +1611,7 @@ describe('LiquidityProtection', () => {
                                             reserveAddress = baseTokenAddress;
                                             otherReserveAddress = networkToken.address;
 
-                                            if (reserve != 0) {
+                                            if (reserve !== 0) {
                                                 // adding more liquidity so that the system has enough pool tokens
                                                 await addProtectedLiquidity(
                                                     poolToken.address,
@@ -1639,9 +1637,9 @@ describe('LiquidityProtection', () => {
                                                 await generateFee();
                                             }
 
-                                            if (rateChange == 1) {
+                                            if (rateChange === 1) {
                                                 await increaseRate(reserveAddress);
-                                            } else if (rateChange == 2) {
+                                            } else if (rateChange === 2) {
                                                 await increaseRate(otherReserveAddress);
                                             }
 
@@ -1650,14 +1648,15 @@ describe('LiquidityProtection', () => {
                                         });
 
                                         const isLoss =
-                                            (protection == PROTECTION_NO_PROTECTION ||
-                                                protection == PROTECTION_PARTIAL_PROTECTION) &&
-                                            rateChange != 0;
-                                        const shouldLock = reserve == 1 || rateChange == 1; // || (rateChange == 0 && withFee);
+                                            (protection === PROTECTION_NO_PROTECTION ||
+                                                protection === PROTECTION_PARTIAL_PROTECTION) &&
+                                            rateChange !== 0;
+                                        const shouldLock = reserve === 1 || rateChange === 1; // || (rateChange == 0 && withFee);
 
                                         if (isLoss) {
+                                            // eslint-disable-next-line max-len
                                             it('verifies that removeLiquidityReturn returns an amount that is smaller than the initial amount', async () => {
-                                                let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
+                                                const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
                                                     owner
                                                 );
                                                 const protectionId = protectionIds[protectionIds.length - 1];
@@ -1673,8 +1672,9 @@ describe('LiquidityProtection', () => {
                                                 expect(amount).to.be.bignumber.lt(reserveAmount);
                                             });
 
+                                            // eslint-disable-next-line max-len
                                             it('verifies that removeLiquidity returns an amount that is smaller than the initial amount', async () => {
-                                                let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
+                                                const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
                                                     owner
                                                 );
                                                 const protectionId = protectionIds[protectionIds.length - 1];
@@ -1697,7 +1697,7 @@ describe('LiquidityProtection', () => {
                                                 const balance = await getBalance(reserveToken, reserveAddress, owner);
 
                                                 let lockedBalance = await getLockedBalance(owner);
-                                                if (reserveAddress == baseTokenAddress) {
+                                                if (reserveAddress === baseTokenAddress) {
                                                     const rate = await getRate(networkToken.address);
                                                     lockedBalance = lockedBalance.mul(rate.n).div(rate.d);
                                                 }
@@ -1707,8 +1707,9 @@ describe('LiquidityProtection', () => {
                                                 );
                                             });
                                         } else if (withFee) {
+                                            // eslint-disable-next-line max-len
                                             it('verifies that removeLiquidityReturn returns an amount that is larger than the initial amount', async () => {
-                                                let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
+                                                const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
                                                     owner
                                                 );
                                                 const protectionId = protectionIds[protectionIds.length - 1];
@@ -1725,7 +1726,7 @@ describe('LiquidityProtection', () => {
                                             });
 
                                             it('verifies that removeLiquidity returns an amount that is larger than the initial amount', async () => {
-                                                let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
+                                                const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
                                                     owner
                                                 );
                                                 const protectionId = protectionIds[protectionIds.length - 1];
@@ -1748,7 +1749,7 @@ describe('LiquidityProtection', () => {
                                                 const balance = await getBalance(reserveToken, reserveAddress, owner);
 
                                                 let lockedBalance = await getLockedBalance(owner);
-                                                if (reserveAddress == baseTokenAddress) {
+                                                if (reserveAddress === baseTokenAddress) {
                                                     const rate = await getRate(networkToken.address);
                                                     lockedBalance = lockedBalance.mul(rate.n).div(rate.d);
                                                 }
@@ -1758,8 +1759,9 @@ describe('LiquidityProtection', () => {
                                                 );
                                             });
                                         } else {
+                                            // eslint-disable-next-line max-len
                                             it('verifies that removeLiquidityReturn returns an amount that is almost equal to the initial amount', async () => {
-                                                let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
+                                                const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
                                                     owner
                                                 );
                                                 const protectionId = protectionIds[protectionIds.length - 1];
@@ -1775,8 +1777,9 @@ describe('LiquidityProtection', () => {
                                                 expectAlmostEqual(amount, reserveAmount);
                                             });
 
+                                            // eslint-disable-next-line max-len
                                             it('verifies that removeLiquidity returns an amount that is almost equal to the initial amount', async () => {
-                                                let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
+                                                const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
                                                     owner
                                                 );
                                                 const protectionId = protectionIds[protectionIds.length - 1];
@@ -1799,7 +1802,7 @@ describe('LiquidityProtection', () => {
                                                 const balance = await getBalance(reserveToken, reserveAddress, owner);
 
                                                 let lockedBalance = await getLockedBalance(owner);
-                                                if (reserveAddress == baseTokenAddress) {
+                                                if (reserveAddress === baseTokenAddress) {
                                                     const rate = await getRate(networkToken.address);
                                                     lockedBalance = lockedBalance.mul(rate.n).div(rate.d);
                                                 }
@@ -1813,7 +1816,7 @@ describe('LiquidityProtection', () => {
 
                                         if (shouldLock) {
                                             it('verifies that removeLiquidity locks network tokens for the caller', async () => {
-                                                let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
+                                                const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
                                                     owner
                                                 );
                                                 const protectionId = protectionIds[protectionIds.length - 1];
@@ -1839,7 +1842,7 @@ describe('LiquidityProtection', () => {
                                             });
                                         } else {
                                             it('verifies that removeLiquidity does not lock network tokens for the caller', async () => {
-                                                let protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
+                                                const protectionIds = await liquidityProtectionStore.protectedLiquidityIds(
                                                     owner
                                                 );
                                                 const protectionId = protectionIds[protectionIds.length - 1];

--- a/solidity/test/LiquidityProtection.js
+++ b/solidity/test/LiquidityProtection.js
@@ -340,7 +340,7 @@ describe('LiquidityProtection', () => {
                 liquidityProtectionStats = await LiquidityProtectionStats.new();
                 liquidityProtectionSystemStore = await LiquidityProtectionSystemStore.new();
                 liquidityProtectionWallet = await TokenHolder.new();
-                liquidityProtection = await LiquidityProtection.new([
+                liquidityProtection = await LiquidityProtection.new(
                     liquidityProtectionSettings.address,
                     liquidityProtectionStore.address,
                     liquidityProtectionStats.address,
@@ -349,7 +349,7 @@ describe('LiquidityProtection', () => {
                     networkTokenGovernance.address,
                     govTokenGovernance.address,
                     checkpointStore.address
-                ]);
+                );
 
                 await liquidityProtectionSettings.grantRole(ROLE_OWNER, liquidityProtection.address, { from: owner });
                 await liquidityProtectionStats.grantRole(ROLE_OWNER, liquidityProtection.address, { from: owner });

--- a/solidity/test/LiquidityProtection.js
+++ b/solidity/test/LiquidityProtection.js
@@ -385,21 +385,6 @@ describe('LiquidityProtection', () => {
 
                 const wallet = await liquidityProtection.wallet.call();
                 expect(wallet).to.eql(liquidityProtectionWallet.address);
-
-                const networkTknGovernance = await liquidityProtection.networkTokenGovernance.call();
-                expect(networkTknGovernance).to.eql(networkTokenGovernance.address);
-
-                const networkTkn = await liquidityProtection.networkToken.call();
-                expect(networkTkn).to.eql(networkToken.address);
-
-                const govTknGovernance = await liquidityProtection.govTokenGovernance.call();
-                expect(govTknGovernance).to.eql(govTokenGovernance.address);
-
-                const govTkn = await liquidityProtection.govToken.call();
-                expect(govTkn).to.eql(govToken.address);
-
-                const lastRemoveCheckpointStore = await liquidityProtection.lastRemoveCheckpointStore.call();
-                expect(lastRemoveCheckpointStore).to.eql(checkpointStore.address);
             });
 
             it('verifies that the owner can transfer the store ownership', async () => {
@@ -489,7 +474,6 @@ describe('LiquidityProtection', () => {
 
                     const poolTokenAvailableSpace = await liquidityProtection.poolAvailableSpace(poolToken.address);
                     const baseTokenAvailableSpace = poolTokenAvailableSpace[0];
-                    const networkTokenAvailableSpace = poolTokenAvailableSpace[1];
 
                     await expectRevert(
                         liquidityProtection.addLiquidity(
@@ -504,6 +488,9 @@ describe('LiquidityProtection', () => {
                         baseToken.address,
                         baseTokenAvailableSpace
                     );
+
+                    const poolTokenAvailableSpace2 = await liquidityProtection.poolAvailableSpace(poolToken.address);
+                    const networkTokenAvailableSpace = poolTokenAvailableSpace2[1];
 
                     await expectRevert(
                         liquidityProtection.addLiquidity(

--- a/solidity/test/LiquidityProtectionAverageRate.js
+++ b/solidity/test/LiquidityProtectionAverageRate.js
@@ -95,7 +95,7 @@ describe('LiquidityProtectionAverageRate', () => {
                 liquidityProtectionStats = await LiquidityProtectionStats.new();
                 liquidityProtectionSystemStore = await LiquidityProtectionSystemStore.new();
                 liquidityProtectionWallet = await TokenHolder.new();
-                liquidityProtection = await LiquidityProtection.new([
+                liquidityProtection = await LiquidityProtection.new(
                     liquidityProtectionSettings.address,
                     liquidityProtectionStore.address,
                     liquidityProtectionStats.address,
@@ -104,7 +104,7 @@ describe('LiquidityProtectionAverageRate', () => {
                     networkTokenGovernance.address,
                     govTokenGovernance.address,
                     checkpointStore.address
-                ]);
+                );
 
                 await liquidityProtectionSettings.grantRole(ROLE_OWNER, liquidityProtection.address, { from: owner });
                 await liquidityProtectionStats.grantRole(ROLE_OWNER, liquidityProtection.address, { from: owner });

--- a/solidity/test/LiquidityProtectionEdgeCases.js
+++ b/solidity/test/LiquidityProtectionEdgeCases.js
@@ -202,7 +202,7 @@ describe('LiquidityProtectionEdgeCases', () => {
                 liquidityProtectionStats = await LiquidityProtectionStats.new();
                 liquidityProtectionSystemStore = await LiquidityProtectionSystemStore.new();
                 liquidityProtectionWallet = await TokenHolder.new();
-                liquidityProtection = await LiquidityProtection.new([
+                liquidityProtection = await LiquidityProtection.new(
                     liquidityProtectionSettings.address,
                     liquidityProtectionStore.address,
                     liquidityProtectionStats.address,
@@ -211,7 +211,7 @@ describe('LiquidityProtectionEdgeCases', () => {
                     networkTokenGovernance.address,
                     govTokenGovernance.address,
                     checkpointStore.address
-                ]);
+                );
 
                 await liquidityProtectionStats.grantRole(ROLE_OWNER, liquidityProtection.address, { from: owner });
                 await liquidityProtectionSystemStore.grantRole(ROLE_OWNER, liquidityProtection.address, {

--- a/solidity/test/LiquidityProtectionStateless.js
+++ b/solidity/test/LiquidityProtectionStateless.js
@@ -34,7 +34,7 @@ describe('LiquidityProtectionStateless', () => {
         const govTokenGovernance = await TokenGovernance.new(defaultSender);
         const checkpointStore = await CheckpointStore.new();
 
-        liquidityProtection = await LiquidityProtection.new([
+        liquidityProtection = await LiquidityProtection.new(
             liquidityProtectionSettings.address,
             liquidityProtectionStore.address,
             liquidityProtectionStats.address,
@@ -43,7 +43,7 @@ describe('LiquidityProtectionStateless', () => {
             networkTokenGovernance.address,
             govTokenGovernance.address,
             checkpointStore.address
-        ]);
+        );
     });
 
     describe('sanity part 1', () => {

--- a/solidity/utils/test_deployment.js
+++ b/solidity/utils/test_deployment.js
@@ -244,8 +244,7 @@ const run = async () => {
             const symbol = await token.methods.symbol().call();
             const decimals = await token.methods.symbol().call();
             reserves[symbol] = { address: token._address, decimals: decimals };
-        }
-        else {
+        } else {
             const name = reserve.symbol + ' DS Token';
             const symbol = reserve.symbol;
             const decimals = reserve.decimals;
@@ -301,7 +300,7 @@ const run = async () => {
                 }
             }
 
-            const deployedConverterType = {1: 'LiquidityPoolV1Converter', 3: 'StandardPoolConverter'}[type];
+            const deployedConverterType = { 1: 'LiquidityPoolV1Converter', 3: 'StandardPoolConverter' }[type];
             const deployedConverter = deployed(web3, deployedConverterType, converterBase._address);
             await execute(deployedConverter.methods.addLiquidity(tokens, amounts, 1), value);
         }
@@ -342,16 +341,14 @@ const run = async () => {
     const liquidityProtectionWallet = await web3Func(deploy, 'liquidityProtectionWallet', 'TokenHolder', []);
 
     const liquidityProtection = await web3Func(deploy, 'liquidityProtection', 'LiquidityProtection', [
-        [
-            liquidityProtectionSettings._address,
-            liquidityProtectionStore._address,
-            liquidityProtectionStats._address,
-            liquidityProtectionSystemStore._address,
-            liquidityProtectionWallet._address,
-            bntTokenGovernance._address,
-            vbntTokenGovernance._address,
-            checkpointStore._address
-        ]
+        liquidityProtectionSettings._address,
+        liquidityProtectionStore._address,
+        liquidityProtectionStats._address,
+        liquidityProtectionSystemStore._address,
+        liquidityProtectionWallet._address,
+        bntTokenGovernance._address,
+        vbntTokenGovernance._address,
+        checkpointStore._address
     ]);
 
     await execute(checkpointStore.methods.grantRole(ROLE_OWNER, liquidityProtection._address));


### PR DESCRIPTION
1. Update `LiquidityProtection` and `TestLiquidityProtection` syles according to the new style.
2. Add required getters
3. Remove the obsoleted `updatingLiquidityOnly` mechanism
4. Remove the unused `baseTokenAvailableSpace` and `networkTokenAvailableSpace` functions
5. Restore explicit constructor
6. Remove unneeded caching of immutable state variables
7. Update and refactor the tests accordingly

