### PR TITLE
Optimize LiquidityProtection.removeLiquidity

### DIFF
--- a/solidity/contracts/helpers/TestLiquidityProtection.sol
+++ b/solidity/contracts/helpers/TestLiquidityProtection.sol
@@ -73,8 +73,8 @@ contract TestLiquidityProtection is LiquidityProtection, TestTime {
     }
 
     function averageRateTest(IDSToken poolToken, IERC20 reserveToken) external view returns (uint256, uint256) {
-        (, , uint256 rateN, uint256 rateD) = reserveTokenRates(poolToken, reserveToken, true);
-        return (rateN, rateD);
+        PackedRates memory packedRates = packRates(poolToken, reserveToken, 0, 0, true);
+        return (packedRates.removeAverageRateN, packedRates.removeAverageRateD);
     }
 
     function removeLiquidityTargetAmountTest(


### PR DESCRIPTION
1. Verify the average rate deviation at the beginning of function `LiquidityProtection.removeLiquidity` instead of half-way through.
2. Some coding reorganization (merge internal function `reserveTokenRates` into internal function `packRates`).
