### PR TITLE
Allow transferring position with an optional external notification callback

### DIFF
--- a/solidity/contracts/helpers/TestCall.sol
+++ b/solidity/contracts/helpers/TestCall.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: SEE LICENSE IN LICENSE
+pragma solidity 0.6.12;
+
+contract TestCall {
+    uint256 private _num;
+    string private _str;
+
+    function num() external view returns (uint256) {
+        return _num;
+    }
+
+    function str() external view returns (string memory) {
+        return _str;
+    }
+
+    function set(uint256 newNum, string calldata newStr) external {
+        _num = newNum;
+        _str = newStr;
+    }
+
+    function error() external pure {
+        revert("ERR_REVERT");
+    }
+}

--- a/solidity/contracts/liquidity-protection/LiquidityProtection.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtection.sol
@@ -783,11 +783,11 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         address newProvider,
         address target,
         bytes memory data
-    ) external protected validAddress(newProvider) returns (uint256) {
+    ) external protected validAddress(newProvider) validAddress(target) returns (uint256) {
         uint256 newId = transferPosition(msg.sender, id, newProvider);
 
         // make sure that we're not trying to call into the zero address or a fallback function
-        require(target != address(0) && data.length >= FUNC_SELECTOR_LENGTH, "ERR_INVALID_CALL_DATA");
+        require(data.length >= FUNC_SELECTOR_LENGTH, "ERR_INVALID_CALL_DATA");
 
         Address.functionCall(target, data, "ERR_CALL_FAILED");
 

--- a/solidity/contracts/liquidity-protection/LiquidityProtection.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtection.sol
@@ -2,6 +2,7 @@
 pragma solidity 0.6.12;
 
 import "@openzeppelin/contracts/math/SafeMath.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
 
 import "@bancor/token-governance/contracts/ITokenGovernance.sol";
 
@@ -753,7 +754,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
      * @dev transfers a position to a new provider
      *
      * @param id position id
-     * @param newProvider new provider
+     * @param newProvider the new provider
      *
      * @return new position id
      */
@@ -763,8 +764,53 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         validAddress(newProvider)
         returns (uint256)
     {
+        return transferPosition(msg.sender, id, newProvider);
+    }
+
+    /**
+     * @dev transfers a position to a new provider and optionally notifies another contract
+     *
+     * @param id position id
+     * @param newProvider the new provider
+     * @param target the contract to notify
+     * @param data the data to call the contract with
+     *
+     * @return new position id
+     */
+    function transferPositionAndCall(
+        uint256 id,
+        address newProvider,
+        address target,
+        bytes memory data
+    ) external protected validAddress(newProvider) returns (uint256) {
+        uint256 newId = transferPosition(msg.sender, id, newProvider);
+
+        // make sure that we're not trying to call into the zero address or a fallback function
+        require(target != address(0) && data.length > 0, "ERR_INVALID_CALL_DATA");
+
+        Address.functionCall(target, data, "ERR_CALL_FAILED");
+
+        return newId;
+    }
+
+    // bytes calldata data
+
+    /**
+     * @dev transfers a position to a new provider
+     *
+     * @param provider the existing provider
+     * @param id position id
+     * @param newProvider the new provider
+     *
+     * @return new position id
+     */
+    function transferPosition(
+        address provider,
+        uint256 id,
+        address newProvider
+    ) internal returns (uint256) {
         // remove the position from the store and update the stats and the last removal checkpoint
-        Position memory removedPos = removePosition(msg.sender, id, PPM_RESOLUTION);
+        Position memory removedPos = removePosition(provider, id, PPM_RESOLUTION);
 
         // add the position to the store, update the stats, and return the new id
         return

--- a/solidity/contracts/liquidity-protection/LiquidityProtection.sol
+++ b/solidity/contracts/liquidity-protection/LiquidityProtection.sol
@@ -73,6 +73,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
 
     uint256 internal constant MAX_UINT128 = 2**128 - 1;
     uint256 internal constant MAX_UINT256 = uint256(-1);
+    uint8 private constant FUNC_SELECTOR_LENGTH = 4;
 
     ILiquidityProtectionSettings private immutable _settings;
     ILiquidityProtectionStore private immutable _store;
@@ -786,7 +787,7 @@ contract LiquidityProtection is ILiquidityProtection, Utils, Owned, ReentrancyGu
         uint256 newId = transferPosition(msg.sender, id, newProvider);
 
         // make sure that we're not trying to call into the zero address or a fallback function
-        require(target != address(0) && data.length > 0, "ERR_INVALID_CALL_DATA");
+        require(target != address(0) && data.length >= FUNC_SELECTOR_LENGTH, "ERR_INVALID_CALL_DATA");
 
         Address.functionCall(target, data, "ERR_CALL_FAILED");
 

--- a/solidity/test/LiquidityProtection.js
+++ b/solidity/test/LiquidityProtection.js
@@ -2240,7 +2240,7 @@ describe('LiquidityProtection', () => {
                                         from: recipient
                                     }
                                 ),
-                                'ERR_INVALID_CALL_DATA'
+                                'ERR_INVALID_ADDRESS'
                             );
 
                             await expectRevert(

--- a/solidity/test/LiquidityProtection.js
+++ b/solidity/test/LiquidityProtection.js
@@ -2139,6 +2139,9 @@ describe('LiquidityProtection', () => {
                         let protection = await liquidityProtectionStore.protectedLiquidity.call(protectionId);
                         protection = getProtection(protection);
 
+                        expect(await checkpointStore.checkpoint.call(recipient)).to.be.bignumber.equal(new BN(0));
+                        expect(await checkpointStore.checkpoint.call(newOwner)).to.be.bignumber.equal(new BN(0));
+
                         const prevPoolStats = await getPoolStats(poolToken, reserveToken, isETHReserve);
                         const prevRecipientStats = await getProviderStats(
                             recipient,
@@ -2196,15 +2199,8 @@ describe('LiquidityProtection', () => {
                             prevNewOwnerStats.totalProviderAmount.add(protection2.reserveAmount)
                         );
                         expect(newOwnerStats.providerPools).to.eql([protection2.poolToken]);
-                    });
 
-                    it('should update the last removal check point when transferring liquidity', async () => {
-                        expect(await checkpointStore.checkpoint.call(recipient)).to.be.bignumber.equal(new BN(0));
-
-                        await liquidityProtection.transferPosition(protectionId, newOwner, {
-                            from: recipient
-                        });
-
+                        // verify removal checkpoints
                         expect(await checkpointStore.checkpoint.call(recipient)).to.be.bignumber.equal(now);
                         expect(await checkpointStore.checkpoint.call(newOwner)).to.be.bignumber.equal(new BN(0));
                     });

--- a/solidity/test/LiquidityProtection.js
+++ b/solidity/test/LiquidityProtection.js
@@ -2235,7 +2235,7 @@ describe('LiquidityProtection', () => {
                                     protectionId,
                                     newOwner,
                                     ZERO_ADDRESS,
-                                    '0x1234',
+                                    liquidityProtection.contract.methods.store().encodeABI(),
                                     {
                                         from: recipient
                                     }
@@ -2255,6 +2255,21 @@ describe('LiquidityProtection', () => {
                                 ),
                                 'ERR_INVALID_CALL_DATA'
                             );
+
+                            for (const invalidCallData of [[], '0x1234', '0x123456']) {
+                                await expectRevert(
+                                    liquidityProtection.transferPositionAndCall(
+                                        protectionId,
+                                        newOwner,
+                                        testCall.address,
+                                        invalidCallData,
+                                        {
+                                            from: recipient
+                                        }
+                                    ),
+                                    'ERR_INVALID_CALL_DATA'
+                                );
+                            }
                         });
 
                         it('should revert when the callback reverts', async () => {


### PR DESCRIPTION
This PR adds the `transferPositionAndCall` function, allowing the caller to specify a custom transfer position notification callback. 